### PR TITLE
fix: ambigious vk in risc0 host

### DIFF
--- a/adapters/risc0/src/host.rs
+++ b/adapters/risc0/src/host.rs
@@ -14,16 +14,16 @@ pub struct Risc0Host {
     /// A vector of bytes containing the guest program in ELF format.
     elf: Vec<u8>,
     /// The verification key computed from the ELF, used to verify the integrity of the program.
-    vk: Digest,
+    image_id: Digest,
 }
 
 impl Risc0Host {
     /// Initializes the Risc0Host with the given ELF.
     pub fn init(elf: &[u8]) -> Self {
-        let vk = compute_image_id(elf).expect("invalid elf");
+        let image_id = compute_image_id(elf).expect("invalid elf");
         Risc0Host {
             elf: elf.to_vec(),
-            vk,
+            image_id,
         }
     }
 
@@ -33,8 +33,8 @@ impl Risc0Host {
     }
 
     /// Returns the verification key (`vk`) associated with the guest program.
-    pub fn vk(&self) -> Digest {
-        self.vk
+    pub fn image_id(&self) -> Digest {
+        self.image_id
     }
 }
 
@@ -42,6 +42,6 @@ impl ZkVmHost for Risc0Host {}
 
 impl fmt::Debug for Risc0Host {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "risc0_{}", encode(self.vk.as_bytes()))
+        write!(f, "risc0_{}", encode(self.image_id.as_bytes()))
     }
 }

--- a/adapters/risc0/src/prover.rs
+++ b/adapters/risc0/src/prover.rs
@@ -56,7 +56,7 @@ impl ZkVmProver for Risc0Host {
 
         // Generate the proof
         let proof_info = prover
-            .prove_with_opts(prover_input, self.elf(), &opts)
+            .prove_with_opts(prover_input, self.get_elf(), &opts)
             .map_err(|e| ZkVmError::ProofGenerationError(e.to_string()))?;
 
         Ok(proof_info.receipt.into())

--- a/adapters/risc0/src/verifier.rs
+++ b/adapters/risc0/src/verifier.rs
@@ -21,17 +21,17 @@ impl ZkVmVerifier for Risc0Host {
     }
 
     fn vk(&self) -> VerifyingKey {
-        VerifyingKey::new(self.vk().as_bytes().to_vec())
+        VerifyingKey::new(self.image_id().as_bytes().to_vec())
     }
 
     fn vk_commitment(&self) -> VerifyingKeyCommitment {
-        VerifyingKeyCommitment::new(self.vk().into())
+        VerifyingKeyCommitment::new(self.image_id().into())
     }
 
     fn verify_inner(&self, proof: &Risc0ProofReceipt) -> ZkVmResult<()> {
         proof
             .as_ref()
-            .verify(self.vk())
+            .verify(self.image_id())
             .map_err(|e| ZkVmError::ProofVerificationError(e.to_string()))?;
         Ok(())
     }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
- Rename `vk()` in Risc0Host -> `image_id` to avoid ambiguity with the `ZkVmVerifier` trait that also provides the `vk()`

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
