### PR TITLE
Fix Typo in TODO Comment in `input.rs`

### DIFF
--- a/adapters/risc0/host/src/input.rs
+++ b/adapters/risc0/host/src/input.rs
@@ -36,7 +36,7 @@ impl<'a> ZkVmInputBuilder<'a> for Risc0ProofInputBuilder<'a> {
         self.write_buf(&slice)
     }
 
-    // TODO: replace this with `write_frame` once the API stabilizies
+    // TODO: replace this with `write_frame` once the API stabilize
     fn write_buf(&mut self, item: &[u8]) -> ZkVmInputResult<&mut Self> {
         let len = item.len() as u32;
         self.0


### PR DESCRIPTION


**Description:** 
This pull request corrects a typo in a TODO comment within the `adapters/risc0/host/src/input.rs` file. The word "stabilizies" has been corrected to "stabilize". This change improves the readability and accuracy of the code comments.
