### PR TITLE
chore(errors): clarify proof data format error message and fix comments

### DIFF
--- a/zkaleido/src/errors.rs
+++ b/zkaleido/src/errors.rs
@@ -135,7 +135,7 @@ where
 #[derive(Debug, Error)]
 pub enum ZkVmProofError {
     /// An error occurred due to a proof data format issue.
-    #[error("Input data format error")]
+    #[error("Proof data format error")]
     DataFormat(#[source] DataFormatError),
 
     /// The proof type provided does not match the expected proof type.
@@ -173,7 +173,7 @@ impl From<borsh::io::Error> for DataFormatError {
     }
 }
 
-/// Implement automatic conversion for `bincode::Error` to `InvalidProofReceipt`
+/// Implement automatic conversion for `bincode::Error` to `ZkVmProofError`
 impl From<bincode::Error> for ZkVmProofError {
     fn from(err: bincode::Error) -> Self {
         let source = DataFormatError::Bincode { source: err };
@@ -181,7 +181,7 @@ impl From<bincode::Error> for ZkVmProofError {
     }
 }
 
-/// Implement automatic conversion for `borsh::io::Error` to `InvalidProofReceiptSource`
+/// Implement automatic conversion for `borsh::io::Error` to `ZkVmProofError`
 impl From<borsh::io::Error> for ZkVmProofError {
     fn from(err: borsh::io::Error) -> Self {
         let source = DataFormatError::Borsh { source: err };


### PR DESCRIPTION
- Change ZkVmProofError::DataFormat message to “Proof data format error” to align with docs and usage.
- Update misleading comments on From<bincode::Error> and From<borsh::io::Error> impls to reference ZkVmProofError.
- No functional behavior changes; improves error clarity and consistency.