### PR TITLE
chore: use SPN as a default option for SP1 adapter

### DIFF
--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -66,7 +66,7 @@ impl ZkVmProver for SP1Host {
             let strategy = std::env::var("SP1_PROOF_STRATEGY")
                 .ok()
                 .and_then(|s| FulfillmentStrategy::from_str_name(&s.to_ascii_uppercase()))
-                .unwrap_or(FulfillmentStrategy::Hosted);
+                .unwrap_or(FulfillmentStrategy::Auction);
 
             let network_prover_builder = prover_client
                 .prove(&self.proving_key, &prover_input)
@@ -127,7 +127,7 @@ impl ZkVmRemoteProver for SP1Host {
         let strategy = std::env::var("SP1_PROOF_STRATEGY")
             .ok()
             .and_then(|s| FulfillmentStrategy::from_str_name(&s.to_ascii_uppercase()))
-            .unwrap_or(FulfillmentStrategy::Hosted);
+            .unwrap_or(FulfillmentStrategy::Auction);
 
         let mode = match proof_type {
             ProofType::Core => SP1ProofMode::Core,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Update usage of SP1 SDK to enable usage of SP1's SPN by default. 

migration guide:
https://docs.succinct.xyz/docs/sp1/prover-network/migration-guide

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
