### PR TITLE
feat: add gas metric to performance report

### DIFF
--- a/adapters/risc0/host/src/perf.rs
+++ b/adapters/risc0/host/src/perf.rs
@@ -42,6 +42,7 @@ impl ZkVmHostPerf for Risc0Host {
         PerformanceReport::new(
             shards,
             cycles,
+            None,
             execution_duration.as_secs_f64(),
             core_proof_report,
             compressed_proof_report,

--- a/adapters/sp1/host/src/perf.rs
+++ b/adapters/sp1/host/src/perf.rs
@@ -20,7 +20,7 @@ impl ZkVmHostPerf for SP1Host {
         let context = SP1Context::default();
         let cycles = get_cycles(elf, &input);
 
-        let (_, execution_duration) =
+        let ((_, _, report), execution_duration) =
             time_operation(|| prover.execute(elf, &input, context.clone()).unwrap());
 
         // If the environment variable "ZKVM_MOCK" is set to "1" or "true" (case-insensitive),
@@ -39,6 +39,7 @@ impl ZkVmHostPerf for SP1Host {
         PerformanceReport::new(
             shards,
             cycles,
+            report.gas,
             execution_duration.as_secs_f64(),
             core_proof_report,
             compressed_proof_report,

--- a/runner/src/format.rs
+++ b/runner/src/format.rs
@@ -19,15 +19,15 @@ pub fn format_header(args: &EvalArgs) -> String {
 pub fn format_results(results: &[PerformanceReport], host_name: String) -> String {
     let mut table_text = String::new();
     table_text.push('\n');
-    table_text.push_str("| program                | cycles      | success  |\n");
+    table_text.push_str("| program                | cycles      | gas      |\n");
     table_text.push_str("|------------------------|-------------|----------|");
 
     for result in results.iter() {
         table_text.push_str(&format!(
-            "\n| {:<22} | {:>11} | {:<7} |",
+            "\n| {:<22} | {:>11} | {:>8} |",
             result.name,
             result.cycles.to_formatted_string(&Locale::en),
-            if result.success { "✅" } else { "❌" }
+            result.gas.unwrap_or(0).to_formatted_string(&Locale::en)
         ));
     }
     table_text.push('\n');

--- a/zkaleido/src/perf.rs
+++ b/zkaleido/src/perf.rs
@@ -26,10 +26,18 @@ pub struct PerformanceReport {
 
     /// The number of shards.
     pub shards: usize,
-    /// The reported number of cycles.
+
+    /// The number of VM execution cycles. Each cycle represents one basic operation
+    /// (e.g., an integer addition). Proving time scales proportionally with this value.
     ///
-    /// Note that this number may vary based on the zkVM.
+    /// The exact definition of a cycle may vary across zkVM backends.
     pub cycles: u64,
+
+    /// Prover gas consumption, a cost metric that accounts for both cycle count and precompile
+    /// cost profiles, giving a more accurate estimate of proving cost than raw cycles alone.
+    ///
+    /// `None` if the zkVM backend does not support gas metering.
+    pub gas: Option<u64>,
 
     /// The duration for execution in seconds
     pub execution_duration: f64,
@@ -58,6 +66,7 @@ impl PerformanceReport {
     pub fn new(
         shards: usize,
         cycles: u64,
+        gas: Option<u64>,
         execution_duration: f64,
         core_proof_report: Option<ProofMetrics>,
         compressed_proof_report: Option<ProofMetrics>,
@@ -83,6 +92,7 @@ impl PerformanceReport {
             name,
             shards,
             cycles,
+            gas,
             execution_duration,
             core_proof_metrics: core_proof_report,
             compressed_proof_metrics: compressed_proof_report,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
- Add `gas: Option<u64>` field to `PerformanceReport` to capture prover gas consumption.
- Populate gas from SP1's execution report; Risc0 passes `None` (no gas metering support).
- Replace the success/failure column in the CI performance table with the gas metric (defaults to `0` when unavailable). The proof metrics is reported only in the case of success, so the success/failure metric is irrelevant.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
