### PR TITLE
fix: make zkaleido-logging noop macros exportable for zkVM builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,6 +2867,7 @@ name = "fibonacci"
 version = "0.1.0"
 dependencies = [
  "zkaleido",
+ "zkaleido-logging",
  "zkaleido-native-adapter",
 ]
 

--- a/examples/fibonacci/Cargo.toml
+++ b/examples/fibonacci/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 zkaleido = { path = "../../zkaleido", features = ["perf"] }
 zkaleido-native-adapter = { path = "../../adapters/native" }
+zkaleido-logging = { path = "../../logging" }

--- a/examples/fibonacci/src/lib.rs
+++ b/examples/fibonacci/src/lib.rs
@@ -1,11 +1,12 @@
 use zkaleido::ZkVmEnv;
+use zkaleido_logging::{debug, info, trace};
 
 pub mod program;
 
 pub fn process_fibonacci(zkvm: &impl ZkVmEnv) {
-    // Read an input to the program.
     let buf = zkvm.read_buf();
     let n = u32::from_le_bytes(buf.try_into().expect("invalid input length"));
+    debug!(?n, "calculating fibonacci number");
 
     // Compute the n'th fibonacci number, using normal Rust code.
     let mut a: u32 = 0;
@@ -15,7 +16,10 @@ pub fn process_fibonacci(zkvm: &impl ZkVmEnv) {
         c %= 7919; // Modulus to prevent overflow.
         a = b;
         b = c;
+        trace!(%a, %b, %c, "iteration");
     }
+
+    info!(%a, "fibonacci value output");
 
     // Write the output of the program.
     zkvm.commit_buf(&a.to_le_bytes());

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -6,9 +6,6 @@
 
 #[cfg(target_os = "zkvm")]
 mod noop;
-
-#[cfg(target_os = "zkvm")]
-pub use noop::{debug, error, info, trace, warn};
 // When NOT building for zkVM, use real tracing macros
 #[cfg(not(target_os = "zkvm"))]
 pub use tracing::{debug, error, info, trace, warn};

--- a/logging/src/noop.rs
+++ b/logging/src/noop.rs
@@ -1,28 +1,32 @@
+/// No-op replacement for `tracing::error!` in zkVM builds.
+#[macro_export]
 macro_rules! error {
     ($($tt:tt)*) => {{}};
 }
 
+/// No-op replacement for `tracing::warn!` in zkVM builds.
+#[macro_export]
 macro_rules! warn {
     ($($tt:tt)*) => {{}};
 }
 
+/// No-op replacement for `tracing::info!` in zkVM builds.
+#[macro_export]
 macro_rules! info {
     ($($tt:tt)*) => {{}};
 }
 
+/// No-op replacement for `tracing::debug!` in zkVM builds.
+#[macro_export]
 macro_rules! debug {
     ($($tt:tt)*) => {{}};
 }
 
+/// No-op replacement for `tracing::trace!` in zkVM builds.
+#[macro_export]
 macro_rules! trace {
     ($($tt:tt)*) => {{}};
 }
-
-pub use debug;
-pub use error;
-pub use info;
-pub use trace;
-pub use warn;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->- 
Fix `zkaleido-logging` noop macros failing to compile when re-exported outside the crate by adding #[macro_export] and removing the invalid pub use re-exports
- Add doc comments to exported noop macros to satisfy `missing_docs` lint
- Add logging to the fibonacci example to exercise `zkaleido-logging` in a guest program

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [X] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [X] I have performed a self-review of my code.
- [X] I have commented my code where necessary.
- [X] I have updated the documentation if needed.
- [X] My changes do not introduce new warnings.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
