### PR TITLE
feat: add a zkvm method on ZkVmHost

### DIFF
--- a/adapters/native/src/host.rs
+++ b/adapters/native/src/host.rs
@@ -79,7 +79,11 @@ impl NativeHost {
     }
 }
 
-impl ZkVmHost for NativeHost {}
+impl ZkVmHost for NativeHost {
+    fn zkvm(&self) -> ZkVm {
+        ZkVm::Native
+    }
+}
 
 impl ZkVmExecutor for NativeHost {
     type Input<'a> = NativeMachineInputBuilder;
@@ -109,6 +113,7 @@ impl ZkVmProver for NativeHost {
     ) -> ZkVmResult<NativeProofReceipt> {
         let execution_result = self.execute(native_machine)?;
         let public_values = execution_result.into_public_values();
+
         // Sign the public values using the Schnorr signing key
         let signature = self.schnorr_key.sign(public_values.as_bytes());
         let proof = Proof::new(signature.to_bytes().to_vec());

--- a/adapters/risc0/host/src/host.rs
+++ b/adapters/risc0/host/src/host.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use hex::encode;
 use risc0_zkvm::{compute_image_id, sha::Digest};
-use zkaleido::ZkVmHost;
+use zkaleido::{ZkVm, ZkVmHost};
 
 /// A host for the `Risc0` zkVM that stores the guest program in ELF format.
 ///
@@ -38,7 +38,11 @@ impl Risc0Host {
     }
 }
 
-impl ZkVmHost for Risc0Host {}
+impl ZkVmHost for Risc0Host {
+    fn zkvm(&self) -> ZkVm {
+        ZkVm::Risc0
+    }
+}
 
 impl fmt::Debug for Risc0Host {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/adapters/sp1/host/src/host.rs
+++ b/adapters/sp1/host/src/host.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use sp1_sdk::{HashableKey, ProverClient, SP1ProvingKey};
-use zkaleido::ZkVmHost;
+use zkaleido::{ZkVm, ZkVmHost};
 
 /// A host for the `SP1` zkVM that stores the guest program in ELF format.
 /// The `SP1Host` is responsible for program execution and proving
@@ -32,7 +32,11 @@ impl SP1Host {
     }
 }
 
-impl ZkVmHost for SP1Host {}
+impl ZkVmHost for SP1Host {
+    fn zkvm(&self) -> ZkVm {
+        ZkVm::SP1
+    }
+}
 
 impl fmt::Debug for SP1Host {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/zkaleido/src/host.rs
+++ b/zkaleido/src/host.rs
@@ -2,7 +2,7 @@
 use crate::ZkVmRemoteProver;
 #[cfg(feature = "perf")]
 use crate::{input::ZkVmInputBuilder, PerformanceReport};
-use crate::{ZkVmOutputExtractor, ZkVmProver, ZkVmTypedVerifier, ZkVmVkProvider};
+use crate::{ZkVm, ZkVmOutputExtractor, ZkVmProver, ZkVmTypedVerifier, ZkVmVkProvider};
 
 /// A trait implemented by the host of a zkVM program.
 ///
@@ -13,7 +13,10 @@ use crate::{ZkVmOutputExtractor, ZkVmProver, ZkVmTypedVerifier, ZkVmVkProvider};
 ///
 /// The host combines the capabilities of both a zkVM prover and a zkVM verifier, as
 /// indicated by its inheritance from the `ZkVmProver` and `ZkVmVerifier` traits.
-pub trait ZkVmHost: ZkVmProver + ZkVmTypedVerifier + ZkVmOutputExtractor + ZkVmVkProvider {}
+pub trait ZkVmHost: ZkVmProver + ZkVmTypedVerifier + ZkVmOutputExtractor + ZkVmVkProvider {
+    /// Returns the [`ZkVm`] backend this host represents.
+    fn zkvm(&self) -> ZkVm;
+}
 
 /// Extends the [`ZkVmHost`] trait by providing functionality to generate performance reports.
 ///


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
`ZkVmHost` is consumed through generics/trait objects, so callers don't know the concrete backend. Adding `fn zkvm(&self) -> ZkVm` lets generic code branch on the backend without downcasting.

This is needed for constructing a `PredicateKey` whose type depends on which zkVM being used.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
