### PR TITLE
feat(sp1-host): expose per-host network proving deadline

### DIFF
--- a/adapters/sp1/host/src/host.rs
+++ b/adapters/sp1/host/src/host.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, time::Duration};
 
 use sp1_sdk::{HashableKey, ProverClient, SP1ProvingKey};
 use zkaleido::{ZkVm, ZkVmHost};
@@ -9,12 +9,18 @@ use zkaleido::{ZkVm, ZkVmHost};
 pub struct SP1Host {
     /// Proving Key
     pub proving_key: SP1ProvingKey,
+    /// Optional deadline passed to the SP1 prover network. When unset, the SP1
+    /// SDK falls back to its own default (auto-calculated from the gas limit).
+    pub(crate) deadline: Option<Duration>,
 }
 
 impl SP1Host {
     /// Creates a new instance of [`SP1Host`] using the provided [`SP1ProvingKey`].
     pub fn new(proving_key: SP1ProvingKey) -> Self {
-        Self { proving_key }
+        Self {
+            proving_key,
+            deadline: None,
+        }
     }
 
     /// Creates a new instance of [`SP1Host`] from serialized proving key bytes.
@@ -28,7 +34,19 @@ impl SP1Host {
     pub fn init(elf: &[u8]) -> Self {
         let client = ProverClient::from_env();
         let (proving_key, _) = client.setup(elf);
-        Self { proving_key }
+        SP1Host::new(proving_key)
+    }
+
+    /// Sets the deadline for remote proof requests submitted through this host.
+    ///
+    /// The deadline is passed to the SP1 prover network on every request; the
+    /// network rejects the proof once the deadline elapses. Affects both the
+    /// synchronous network path in [`ZkVmProver::prove_inner`] (when
+    /// `SP1_PROVER=network`) and the async [`ZkVmRemoteProver::start_proving`] path.
+    #[must_use]
+    pub fn with_deadline(mut self, deadline: Duration) -> Self {
+        self.deadline = Some(deadline);
+        self
     }
 }
 

--- a/adapters/sp1/host/src/host.rs
+++ b/adapters/sp1/host/src/host.rs
@@ -15,11 +15,15 @@ pub struct SP1Host {
 }
 
 impl SP1Host {
-    /// Creates a new instance of [`SP1Host`] using the provided [`SP1ProvingKey`].
-    pub fn new(proving_key: SP1ProvingKey) -> Self {
+    /// Creates a new instance of [`SP1Host`] using the provided [`SP1ProvingKey`] and
+    /// an optional deadline for remote proof requests.
+    ///
+    /// Pass `None` for `deadline` to let the SP1 SDK fall back to its own default
+    /// (auto-calculated from the gas limit).
+    pub fn new(proving_key: SP1ProvingKey, deadline: Option<Duration>) -> Self {
         Self {
             proving_key,
-            deadline: None,
+            deadline,
         }
     }
 
@@ -27,14 +31,14 @@ impl SP1Host {
     pub fn new_from_pk_bytes(proving_key_bytes: &[u8]) -> Self {
         let proving_key: SP1ProvingKey =
             bincode::deserialize(proving_key_bytes).expect("invalid sp1 pk bytes");
-        SP1Host::new(proving_key)
+        SP1Host::new(proving_key, None)
     }
 
     /// Initializes a new [`SP1Host`] by setting up the proving key using the provided ELF bytes.
     pub fn init(elf: &[u8]) -> Self {
         let client = ProverClient::from_env();
         let (proving_key, _) = client.setup(elf);
-        SP1Host::new(proving_key)
+        SP1Host::new(proving_key, None)
     }
 
     /// Sets the deadline for remote proof requests submitted through this host.

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -73,9 +73,12 @@ impl ZkVmProver for SP1Host {
                 .and_then(|s| FulfillmentStrategy::from_str_name(&s.to_ascii_uppercase()))
                 .unwrap_or(FulfillmentStrategy::Auction);
 
-            let network_prover_builder = prover_client
+            let mut network_prover_builder = prover_client
                 .prove(&self.proving_key, &prover_input)
                 .strategy(strategy);
+            if let Some(deadline) = self.deadline {
+                network_prover_builder = network_prover_builder.timeout(deadline);
+            }
 
             let network_prover = match proof_type {
                 ProofType::Compressed => network_prover_builder.compressed(),

--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -65,10 +65,11 @@ impl ZkVmRemoteProver for SP1Host {
         };
 
         let pk = &self.proving_key;
-        let request_id = client
-            .prove(pk, &input)
-            .strategy(strategy)
-            .mode(mode)
+        let mut builder = client.prove(pk, &input).strategy(strategy).mode(mode);
+        if let Some(deadline) = self.deadline {
+            builder = builder.timeout(deadline);
+        }
+        let request_id = builder
             .request_async()
             .await
             .map_err(|e| ZkVmError::ProofGenerationError(e.to_string()))?;


### PR DESCRIPTION
## Summary

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Adds `SP1Host::with_deadline(Duration)` — an opt-in knob that configures the end-to-end deadline passed to the SP1 prover network on every proof request.

Today, zkaleido never sets `.timeout(...)` on SP1's `NetworkProveBuilder`. SP1 falls back to its internal default (auto-calculated from the gas limit in 5.2.1), which can leave callers hanging on a stuck request with no caller-side control.

The deadline is stored on the host and applied in both proving paths:
- Sync network path: `ZkVmProver::prove_inner` when `SP1_PROVER=network` (`prover.rs`)
- Async path: `ZkVmRemoteProver::start_proving` (`remote_prover.rs`)

Trait signatures are unchanged; `risc0` and `native` adapters are unaffected.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->