### PR TITLE
feat(native-host): add with_key and with_key_fallible constructors

### DIFF
--- a/adapters/native/src/host.rs
+++ b/adapters/native/src/host.rs
@@ -77,6 +77,38 @@ impl NativeHost {
             schnorr_key,
         }
     }
+
+    /// Creates a new [`NativeHost`] with the given signing key and proof processing function.
+    ///
+    /// This can be used when you need the same verifying key across restarts. For fallible
+    /// functions, use [`with_key_fallible`](Self::with_key_fallible).
+    pub fn with_key<F>(signing_key: SigningKey, process_fn: F) -> Self
+    where
+        F: Fn(&NativeMachine) + Send + Sync + 'static,
+    {
+        Self {
+            process_fn: Arc::new(Box::new(move |zkvm: &NativeMachine| -> ZkVmResult<()> {
+                process_fn(zkvm);
+                Ok(())
+            })),
+            schnorr_key: signing_key,
+        }
+    }
+
+    /// Creates a new [`NativeHost`] with the given signing key and a fallible proof processing
+    /// function.
+    ///
+    /// This can be used when you need the same verifying key across restarts. For infallible
+    /// functions, use [`with_key`](Self::with_key).
+    pub fn with_key_fallible<F>(signing_key: SigningKey, process_fn: F) -> Self
+    where
+        F: Fn(&NativeMachine) -> ZkVmResult<()> + Send + Sync + 'static,
+    {
+        Self {
+            process_fn: Arc::new(Box::new(process_fn)),
+            schnorr_key: signing_key,
+        }
+    }
 }
 
 impl ZkVmHost for NativeHost {

--- a/adapters/native/src/host.rs
+++ b/adapters/native/src/host.rs
@@ -42,65 +42,29 @@ pub struct NativeHost {
 }
 
 impl NativeHost {
-    /// Creates a new [`NativeHost`] with the given proof processing function.
-    ///
-    /// Generates a fresh Schnorr signing key pair to sign and verify proof outputs,
-    /// providing authenticity guarantees for native execution.
-    ///
-    /// This method accepts infallible functions that return `()`. For functions that
-    /// may fail and return `ZkVmResult<()>`, use [`new_fallible`](Self::new_fallible) instead.
-    pub fn new<F>(process_fn: F) -> Self
-    where
-        F: Fn(&NativeMachine) + Send + Sync + 'static,
-    {
-        let schnorr_key = SigningKey::random(&mut OsRng);
-        Self {
-            process_fn: Arc::new(Box::new(move |zkvm: &NativeMachine| -> ZkVmResult<()> {
-                process_fn(zkvm);
-                Ok(())
-            })),
-            schnorr_key,
-        }
-    }
-
-    /// Creates a new [`NativeHost`] with a fallible proof processing function.
-    ///
-    /// Use this method when your processing function may fail and returns `ZkVmResult<()>`.
-    /// For infallible functions that return `()`, use [`new`](Self::new) instead.
-    pub fn new_fallible<F>(process_fn: F) -> Self
-    where
-        F: Fn(&NativeMachine) -> ZkVmResult<()> + Send + Sync + 'static,
-    {
-        let schnorr_key = SigningKey::random(&mut OsRng);
-        Self {
-            process_fn: Arc::new(Box::new(process_fn)),
-            schnorr_key,
-        }
-    }
-
-    /// Creates a new [`NativeHost`] with the given signing key and proof processing function.
-    ///
-    /// This can be used when you need the same verifying key across restarts. For fallible
-    /// functions, use [`with_key_fallible`](Self::with_key_fallible).
-    pub fn with_key<F>(signing_key: SigningKey, process_fn: F) -> Self
-    where
-        F: Fn(&NativeMachine) + Send + Sync + 'static,
-    {
-        Self {
-            process_fn: Arc::new(Box::new(move |zkvm: &NativeMachine| -> ZkVmResult<()> {
-                process_fn(zkvm);
-                Ok(())
-            })),
-            schnorr_key: signing_key,
-        }
-    }
-
-    /// Creates a new [`NativeHost`] with the given signing key and a fallible proof processing
+    /// Creates a new [`NativeHost`] from the given signing key and an infallible processing
     /// function.
     ///
-    /// This can be used when you need the same verifying key across restarts. For infallible
-    /// functions, use [`with_key`](Self::with_key).
-    pub fn with_key_fallible<F>(signing_key: SigningKey, process_fn: F) -> Self
+    /// Pass the signing key when you need the verifying key to stay stable across restarts.
+    /// For a fallible processing function, use [`new_fallible`](Self::new_fallible); to let the
+    /// host pick a key for you, use [`new_with_random_key`](Self::new_with_random_key).
+    pub fn new<F>(signing_key: SigningKey, process_fn: F) -> Self
+    where
+        F: Fn(&NativeMachine) + Send + Sync + 'static,
+    {
+        Self::new_fallible(signing_key, move |zkvm: &NativeMachine| -> ZkVmResult<()> {
+            process_fn(zkvm);
+            Ok(())
+        })
+    }
+
+    /// Creates a new [`NativeHost`] from the given signing key and a fallible processing
+    /// function.
+    ///
+    /// Pass the signing key when you need the verifying key to stay stable across restarts.
+    /// For an infallible processing function, use [`new`](Self::new); to let the host pick a
+    /// key for you, use [`new_fallible_with_random_key`](Self::new_fallible_with_random_key).
+    pub fn new_fallible<F>(signing_key: SigningKey, process_fn: F) -> Self
     where
         F: Fn(&NativeMachine) -> ZkVmResult<()> + Send + Sync + 'static,
     {
@@ -108,6 +72,33 @@ impl NativeHost {
             process_fn: Arc::new(Box::new(process_fn)),
             schnorr_key: signing_key,
         }
+    }
+
+    /// Creates a new [`NativeHost`] with a freshly generated Schnorr signing key.
+    ///
+    /// Handy for tests or short-lived hosts where a stable verifying key is not required.
+    /// For a fallible processing function, use
+    /// [`new_fallible_with_random_key`](Self::new_fallible_with_random_key); to supply your own
+    /// key, use [`new`](Self::new).
+    pub fn new_with_random_key<F>(process_fn: F) -> Self
+    where
+        F: Fn(&NativeMachine) + Send + Sync + 'static,
+    {
+        Self::new(SigningKey::random(&mut OsRng), process_fn)
+    }
+
+    /// Creates a new [`NativeHost`] with a freshly generated Schnorr signing key and a fallible
+    /// processing function.
+    ///
+    /// Handy for tests or short-lived hosts where a stable verifying key is not required.
+    /// For an infallible processing function, use
+    /// [`new_with_random_key`](Self::new_with_random_key); to supply your own key, use
+    /// [`new_fallible`](Self::new_fallible).
+    pub fn new_fallible_with_random_key<F>(process_fn: F) -> Self
+    where
+        F: Fn(&NativeMachine) -> ZkVmResult<()> + Send + Sync + 'static,
+    {
+        Self::new_fallible(SigningKey::random(&mut OsRng), process_fn)
     }
 }
 

--- a/examples/fibonacci/src/program.rs
+++ b/examples/fibonacci/src/program.rs
@@ -44,7 +44,7 @@ pub mod tests {
     use crate::{process_fibonacci, program::FibProgram};
 
     pub fn get_native_host() -> NativeHost {
-        NativeHost::new(process_fibonacci)
+        NativeHost::new_with_random_key(process_fibonacci)
     }
 
     #[test]

--- a/examples/groth16-verify-sp1/src/program.rs
+++ b/examples/groth16-verify-sp1/src/program.rs
@@ -43,7 +43,7 @@ mod tests {
     };
 
     fn get_native_host() -> NativeHost {
-        NativeHost::new(process_groth16_verify_sp1)
+        NativeHost::new_with_random_key(process_groth16_verify_sp1)
     }
 
     #[test]

--- a/examples/schnorr-sig-verify/src/program.rs
+++ b/examples/schnorr-sig-verify/src/program.rs
@@ -46,7 +46,7 @@ mod tests {
     use crate::process_schnorr_sig_verify;
 
     fn get_native_host() -> NativeHost {
-        NativeHost::new(process_schnorr_sig_verify)
+        NativeHost::new_with_random_key(process_schnorr_sig_verify)
     }
 
     #[test]

--- a/examples/sha2-chain/src/program.rs
+++ b/examples/sha2-chain/src/program.rs
@@ -39,7 +39,7 @@ mod tests {
     use crate::{process_sha2_chain, program::ShaChainProgram};
 
     fn get_native_host() -> NativeHost {
-        NativeHost::new(process_sha2_chain)
+        NativeHost::new_with_random_key(process_sha2_chain)
     }
 
     #[test]


### PR DESCRIPTION
## Description
`NativeHost::new` and `new_fallible` currently generate a new Schnorr key on each process start, causing the verifying key to change across restarts and breaking external proof verification.

This PR adds `with_key` and `with_key_fallible`, which behave like the existing constructors but accept a caller-provided SigningKey instead of generating one.
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update