### PR TITLE
fix(sp1-host): reject non-zero guest exit code at execute/prove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10179,6 +10179,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-verifier",
  "tokio",

--- a/adapters/sp1/host/Cargo.toml
+++ b/adapters/sp1/host/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 workspace = true
 
 [dependencies]
+sp1-core-executor.workspace = true
 sp1-sdk = { workspace = true, features = ["blocking", "network"] }
 sp1-verifier.workspace = true
 zkaleido = { workspace = true, features = ["remote-prover"] }

--- a/adapters/sp1/host/src/config.rs
+++ b/adapters/sp1/host/src/config.rs
@@ -26,6 +26,22 @@ pub struct SP1HostConfig {
     /// Falls back to `SP1_NETWORK_POLL_ENV_MS` (milliseconds) in
     /// [`from_env`](Self::from_env), defaulting to 1 second.
     pub network_poll_interval: Duration,
+    /// When `true`, [`crate::SP1Host`]'s execute path and the pre-flight
+    /// inside its start_proving / prove_inner paths reject guests that
+    /// halted with a non-zero `report.exit_code` (panicked), returning
+    /// [`zkaleido::ZkVmError::ExecutionError`]. Mirrors `require_success`
+    /// on `SP1Groth16Verifier` in the `zkaleido-sp1-groth16-verifier`
+    /// crate.
+    ///
+    /// The SP1 executor and the SDK's network simulation both accept a
+    /// non-zero exit code as a successful run, so without this gate the
+    /// host would silently submit network requests the guest is going to
+    /// panic on. Defaults to `true`; set to `false` to opt back into the
+    /// permissive behavior (e.g. testing a guest's panic path end-to-end).
+    /// Falls back to `SP1_REQUIRE_SUCCESS` (`true` / `false`,
+    /// case-insensitive) in [`from_env`](Self::from_env); unparsable
+    /// values default to `true`.
+    pub require_success: bool,
 }
 
 impl SP1HostConfig {
@@ -58,10 +74,16 @@ impl SP1HostConfig {
             .map(Duration::from_millis)
             .unwrap_or(DEFAULT_NETWORK_POLL_INTERVAL);
 
+        let require_success = var("SP1_REQUIRE_SUCCESS")
+            .ok()
+            .and_then(|s| s.parse::<bool>().ok())
+            .unwrap_or(true);
+
         Self {
             deadline,
             proof_strategy,
             network_poll_interval,
+            require_success,
         }
     }
 
@@ -80,6 +102,12 @@ impl SP1HostConfig {
     #[must_use]
     pub fn with_network_poll_interval(mut self, interval: Duration) -> Self {
         self.network_poll_interval = interval;
+        self
+    }
+
+    #[must_use]
+    pub fn with_require_success(mut self, require_success: bool) -> Self {
+        self.require_success = require_success;
         self
     }
 }

--- a/adapters/sp1/host/src/config.rs
+++ b/adapters/sp1/host/src/config.rs
@@ -76,7 +76,7 @@ impl SP1HostConfig {
 
         let require_success = var("SP1_REQUIRE_SUCCESS")
             .ok()
-            .and_then(|s| s.parse::<bool>().ok())
+            .and_then(|s| s.to_ascii_lowercase().parse::<bool>().ok())
             .unwrap_or(true);
 
         Self {

--- a/adapters/sp1/host/src/lib.rs
+++ b/adapters/sp1/host/src/lib.rs
@@ -19,6 +19,10 @@
 //!   or unparsable defers to the SP1 SDK default (auto-derived from the gas limit).
 //! - `SP1_NETWORK_POLL_ENV_MS` — poll cadence for `get_status` on the synchronous network proving
 //!   path, in milliseconds. Defaults to `1000` (1 second) when unset or unparsable.
+//! - `SP1_REQUIRE_SUCCESS` — when `true` (default), the host's execute path and the pre-flight
+//!   inside its start_proving / prove_inner paths reject guests that halt with a non-zero
+//!   `report.exit_code` (panicked). Set to `false` to opt back into the SDK's permissive behavior
+//!   (e.g. testing a panic path end-to-end). Unparsable values default to `true`.
 //!
 //! Upstream SP1 envs such as `SP1_PROVER` (prover backend) and `ZKVM_MOCK`
 //! (mock mode) are read by the SP1 SDK itself and continue to apply; see

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -3,6 +3,7 @@ use std::{
     future::{Future, IntoFuture},
 };
 
+use sp1_core_executor::ExecutionReport;
 use sp1_sdk::{HashableKey, ProveRequest, Prover, ProvingKey, SP1ProofMode, env::EnvProver};
 use tokio::{
     runtime::{Handle, Runtime},
@@ -25,6 +26,8 @@ impl ZkVmExecutor for SP1Host {
         let elf = self.proving_key.elf().clone();
         let (output, report) = block_on_async(self.client.execute(elf, prover_input).into_future())
             .map_err(|e| ZkVmError::ExecutionError(e.to_string()))?;
+
+        ensure_clean_exit(&report)?;
 
         let public_values = PublicValues::new(output.to_vec());
 
@@ -64,6 +67,12 @@ impl ZkVmProver for SP1Host {
         if matches!(self.client, EnvProver::Network(_)) {
             return block_on_async(self.prove_via_network(prover_input, proof_type));
         }
+
+        // Pre-flight: the local CPU prover would happily produce a proof
+        // whose public values carry exit_code=1 (verifiable as panicked
+        // by a downstream verifier). Fail fast with the same honest
+        // ExecutionError the network path produces.
+        <Self as ZkVmExecutor>::execute(self, prover_input.clone())?;
 
         let mode = to_sp1_mode(proof_type);
         let proof_info = block_on_async(async {
@@ -140,5 +149,56 @@ where
             let rt = Runtime::new().expect("failed to build tokio runtime for sp1 prove");
             rt.block_on(future)
         }
+    }
+}
+
+/// Converts an [`ExecutionReport`] with a non-zero `exit_code` into
+/// [`ZkVmError::ExecutionError`].
+///
+/// The SP1 executor returns `Ok((pv, report))` even when the guest halted
+/// with a non-zero exit code (panic). Without this check, a panicking
+/// guest looks like a successful simulation — and the SDK's network
+/// simulation path makes the same mistake, which is how a request the
+/// guest will panic on can reach the network. SP1's
+/// `SP1Context::expected_exit_code` does not help: that field is only
+/// consulted by the verifier, never by the executor.
+///
+/// The cycle count is included in the message so operators can correlate
+/// against the `panicked at ...` line the guest's panic handler prints
+/// to stderr — the panic string itself isn't carried in
+/// [`ExecutionReport`] (no panic-message field exists in SP1 6.2).
+fn ensure_clean_exit(report: &ExecutionReport) -> ZkVmResult<()> {
+    if report.exit_code != 0 {
+        return Err(ZkVmError::ExecutionError(format!(
+            "guest exited with non-zero exit code {} after {} instructions",
+            report.exit_code,
+            report.total_instruction_count(),
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_clean_exit_rejects_non_zero_exit_code() {
+        let mut report = ExecutionReport::default();
+        report.exit_code = 1;
+        let err = ensure_clean_exit(&report).expect_err("non-zero exit must error");
+        match err {
+            ZkVmError::ExecutionError(msg) => {
+                assert!(msg.contains("exit code 1"), "got: {msg}");
+                assert!(msg.contains("instructions"), "got: {msg}");
+            }
+            other => panic!("expected ExecutionError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ensure_clean_exit_accepts_success() {
+        // Default ExecutionReport has exit_code = 0.
+        assert!(ensure_clean_exit(&ExecutionReport::default()).is_ok());
     }
 }

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -27,7 +27,9 @@ impl ZkVmExecutor for SP1Host {
         let (output, report) = block_on_async(self.client.execute(elf, prover_input).into_future())
             .map_err(|e| ZkVmError::ExecutionError(e.to_string()))?;
 
-        ensure_clean_exit(&report)?;
+        if self.config.require_success {
+            ensure_clean_exit(&report)?;
+        }
 
         let public_values = PublicValues::new(output.to_vec());
 

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -167,7 +167,7 @@ where
 /// against the `panicked at ...` line the guest's panic handler prints
 /// to stderr — the panic string itself isn't carried in
 /// [`ExecutionReport`] (no panic-message field exists in SP1 6.2).
-fn ensure_clean_exit(report: &ExecutionReport) -> ZkVmResult<()> {
+pub(crate) fn ensure_clean_exit(report: &ExecutionReport) -> ZkVmResult<()> {
     if report.exit_code != 0 {
         return Err(ZkVmError::ExecutionError(format!(
             "guest exited with non-zero exit code {} after {} instructions",

--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -87,7 +87,9 @@ impl ZkVmRemoteProver for SP1Host {
             .into_future()
             .await
             .map_err(|e| ZkVmError::ExecutionError(e.to_string()))?;
-        ensure_clean_exit(&report)?;
+        if self.config.require_success {
+            ensure_clean_exit(&report)?;
+        }
         // Mirrors `sp1_sdk::network::DEFAULT_GAS_LIMIT` (pub(crate) so we
         // cannot import it). The SDK uses the same fallback when its own
         // simulation returns a report with `gas = None`.

--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -1,7 +1,7 @@
-use std::fmt;
+use std::{fmt, future::IntoFuture};
 
 use sp1_sdk::{
-    NetworkProver, ProveRequest, Prover,
+    NetworkProver, ProveRequest, Prover, ProvingKey,
     env::{EnvProver, EnvProvingKey},
     network::{
         B256, Error as NetworkError,
@@ -16,7 +16,11 @@ use zkaleido::{
     ZkVmExecutor, ZkVmInputBuilder, ZkVmRemoteProver, ZkVmResult,
 };
 
-use crate::{SP1Host, proof::SP1ProofReceipt, prover::to_sp1_mode};
+use crate::{
+    SP1Host,
+    proof::SP1ProofReceipt,
+    prover::{ensure_clean_exit, to_sp1_mode},
+};
 
 /// A typed proof identifier for the SP1 network prover.
 ///
@@ -69,13 +73,27 @@ impl ZkVmRemoteProver for SP1Host {
         // network builder with `.skip_simulation(true)` so the SDK does
         // not re-run the executor on the same input. Net cost: one
         // simulation per submission, ours, which fails fast on panic.
-        let summary = <Self as ZkVmExecutor>::execute(self, input.clone())?;
+        //
+        // We drive SP1's async executor directly with `.await` instead of
+        // calling [`ZkVmExecutor::execute`] (the sync trait method).
+        // The sync path routes through [`crate::prover::block_on_async`],
+        // which uses [`tokio::task::block_in_place`] (thus making its
+        // usage in async context here error-prone and tokio runtime
+        // dependent).
+        let elf = self.proving_key.elf().clone();
+        let (_, report) = self
+            .client
+            .execute(elf, input.clone())
+            .into_future()
+            .await
+            .map_err(|e| ZkVmError::ExecutionError(e.to_string()))?;
+        ensure_clean_exit(&report)?;
         // Mirrors `sp1_sdk::network::DEFAULT_GAS_LIMIT` (pub(crate) so we
         // cannot import it). The SDK uses the same fallback when its own
         // simulation returns a report with `gas = None`.
         const DEFAULT_GAS_LIMIT: u64 = 1_000_000_000;
-        let cycle_limit = summary.cycles();
-        let gas_limit = summary.gas().unwrap_or(DEFAULT_GAS_LIMIT);
+        let cycle_limit = report.total_instruction_count();
+        let gas_limit = report.gas().unwrap_or(DEFAULT_GAS_LIMIT);
 
         let mut builder = client
             .prove(pk, input)

--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -62,10 +62,28 @@ impl ZkVmRemoteProver for SP1Host {
             _ => unreachable!("we validate that the client is network above"),
         };
 
+        // Pre-flight: run an honest local execute. Without this, the SDK's
+        // simulation inside `.request().await` would happily submit a
+        // request whose guest panics — the SDK's simulation doesn't
+        // enforce exit_code. We then pass the resulting cycle/gas to the
+        // network builder with `.skip_simulation(true)` so the SDK does
+        // not re-run the executor on the same input. Net cost: one
+        // simulation per submission, ours, which fails fast on panic.
+        let summary = <Self as ZkVmExecutor>::execute(self, input.clone())?;
+        // Mirrors `sp1_sdk::network::DEFAULT_GAS_LIMIT` (pub(crate) so we
+        // cannot import it). The SDK uses the same fallback when its own
+        // simulation returns a report with `gas = None`.
+        const DEFAULT_GAS_LIMIT: u64 = 1_000_000_000;
+        let cycle_limit = summary.cycles();
+        let gas_limit = summary.gas().unwrap_or(DEFAULT_GAS_LIMIT);
+
         let mut builder = client
             .prove(pk, input)
             .strategy(self.config.proof_strategy)
-            .mode(to_sp1_mode(proof_type));
+            .mode(to_sp1_mode(proof_type))
+            .skip_simulation(true)
+            .cycle_limit(cycle_limit)
+            .gas_limit(gas_limit);
         if let Some(deadline) = self.config.deadline {
             builder = builder.timeout(deadline);
         }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

RELATED: [STR-3533](https://alpenlabs.atlassian.net/browse/STR-3533)

The SP1 executor returns `Ok((pv, report))` even when the guest panicked
(exit_code != 0). Both `ZkVmExecutor::execute` and the SDK's network
simulation inside `.request().await` accept that as success, so a request
the guest will panic on reaches the network and we pay for a slot the
prover cannot fulfill.

- **execute**: an `ensure_clean_exit(&ExecutionReport)` helper returns
  `ZkVmError::ExecutionError` with the exit code and cycle count when
  non-zero. 
- **start_proving**: pre-flight execute, then build the prove request with
  `.skip_simulation(true)` + cycle/gas limits from the pre-flight, so the
  SDK does not redundantly re-simulate. Net cost: one execute per
  submission — same as today, but ours is honest.
- **prove_inner** local branch: same pre-flight, catches panics before the
  local prover wastes cycles on a doomed input.

All three paths do the check through a single source -- a `ZkVmExecutor` for the adapter (inlined in the async codepath).

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->


[STR-3533]: https://alpenlabs.atlassian.net/browse/STR-3533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ