### PR TITLE
refactor(zkaleido)!: require Send futures from ZkVmRemoteProver

### DIFF
--- a/adapters/native/src/host.rs
+++ b/adapters/native/src/host.rs
@@ -249,7 +249,7 @@ impl From<Vec<u8>> for NativeProofId {
 /// this automatically gives `NativeHost` the `ZkVmRemoteHost` trait, allowing it to work
 /// seamlessly with async/remote proving interfaces.
 #[cfg(feature = "remote-prover")]
-#[async_trait(?Send)]
+#[async_trait]
 impl ZkVmRemoteProver for NativeHost {
     type ProofId = NativeProofId;
 

--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -50,7 +50,7 @@ impl TryFrom<Vec<u8>> for Sp1ProofId {
     }
 }
 
-#[async_trait::async_trait(?Send)]
+#[async_trait::async_trait]
 impl ZkVmRemoteProver for SP1Host {
     type ProofId = Sp1ProofId;
 

--- a/zkaleido/src/remote_prover.rs
+++ b/zkaleido/src/remote_prover.rs
@@ -72,7 +72,7 @@ impl Display for RemoteProofFailureReason {
 /// It provides methods to start the proving process, check its status, and retrieve
 /// the proof once it becomes available. Implementers of this trait typically handle
 /// the remote communication required to generate and fetch proofs.
-#[async_trait(?Send)]
+#[async_trait]
 pub trait ZkVmRemoteProver: ZkVmProver {
     /// A typed proof identifier returned by [`start_proving`](Self::start_proving).
     ///


### PR DESCRIPTION
## Description

Drops the `#[async_trait(?Send)]` opt-out on `ZkVmRemoteProver` so the futures returned by `start_proving` / `get_status` / `get_proof` are `Send`.

**Why:** downstream consumers that drive multiple proof workers want to `tokio::spawn` these futures directly on a multi-threaded runtime. With `?Send`, they're forced into a `LocalSet` + dedicated-thread wrapper just to co-host two `!Send` workers, which is purely an artifact of this trait bound rather than anything the impls actually require.

Both in-tree impls (`NativeHost`, `SP1Host`) were already `Send`-clean — neither holds an `Rc`/`RefCell` across `.await`, and the SP1 SDK client is built for multi-threaded use. Only the trait/impl attributes change; no impl bodies are touched. `cargo check --all-features` on `zkaleido`, `zkaleido-native-adapter`, and `zkaleido-sp1-host` is clean.

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor

## Notes to Reviewers

The breaking change is for **external** `ZkVmRemoteProver` impls only: they must now keep their state `Send` across `.await` (no `Rc`/`RefCell`/raw pointers in scope at suspension points). For impls backed by a typical async HTTP / RPC client this is already the case.

In-repo impact is just the attribute change on the two impls — see the diff.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

n/a