### PR TITLE
fix(sp1-host): unify error mapping for remote prover submission

### DIFF
--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -119,7 +119,7 @@ impl ZkVmRemoteProver for SP1Host {
         let request_id = builder
             .request()
             .await
-            .map_err(|e| ZkVmError::NetworkRetryableError(e.to_string()))?;
+            .map_err(|e| ZkVmError::RemoteProverError(e.to_string()))?;
 
         Ok(Sp1ProofId(request_id))
     }
@@ -129,7 +129,7 @@ impl ZkVmRemoteProver for SP1Host {
         let (status, _) = client
             .get_proof_status(id.0)
             .await
-            .map_err(|e| ZkVmError::NetworkRetryableError(e.to_string()))?;
+            .map_err(|e| ZkVmError::RemoteProverError(e.to_string()))?;
 
         Ok(convert_proof_status(status))
     }
@@ -139,7 +139,7 @@ impl ZkVmRemoteProver for SP1Host {
         let (_, proof) = client
             .get_proof_status(id.0)
             .await
-            .map_err(|e| ZkVmError::NetworkRetryableError(e.to_string()))?;
+            .map_err(|e| ZkVmError::RemoteProverError(e.to_string()))?;
 
         let proof = proof.ok_or(ZkVmError::ProofNotReady)?;
         SP1ProofReceipt::new(proof, self.program_id())

--- a/adapters/sp1/host/src/remote_prover.rs
+++ b/adapters/sp1/host/src/remote_prover.rs
@@ -4,7 +4,7 @@ use sp1_sdk::{
     NetworkProver, ProveRequest, Prover, ProvingKey,
     env::{EnvProver, EnvProvingKey},
     network::{
-        B256, Error as NetworkError,
+        B256,
         proto::{
             GetProofRequestStatusResponse,
             types::{ExecutionStatus, FulfillmentStatus},
@@ -107,16 +107,19 @@ impl ZkVmRemoteProver for SP1Host {
         if let Some(deadline) = self.config.deadline {
             builder = builder.timeout(deadline);
         }
-        let request_id =
-            builder
-                .request()
-                .await
-                .map_err(|e| match e.downcast_ref::<NetworkError>() {
-                    Some(NetworkError::RpcError(status)) => {
-                        ZkVmError::NetworkRetryableError(status.to_string())
-                    }
-                    _ => ZkVmError::ProofGenerationError(e.to_string()),
-                })?;
+        // The SDK has already exhausted its internal transient-error retry
+        // budget by the time an error escapes `.request()` (see
+        // `network::retry::retry_operation`), so the precise gRPC code
+        // doesn't tell us much here. We also can't usefully downcast to
+        // `network::Error` — the gRPC failures are propagated as bare
+        // `tonic::Status` wrapped in `anyhow::Error`, never converted
+        // into `network::Error::RpcError`. Treat all submission failures
+        // uniformly and let the caller decide whether to retry the whole
+        // operation, matching the polling calls below.
+        let request_id = builder
+            .request()
+            .await
+            .map_err(|e| ZkVmError::NetworkRetryableError(e.to_string()))?;
 
         Ok(Sp1ProofId(request_id))
     }

--- a/zkaleido/src/errors.rs
+++ b/zkaleido/src/errors.rs
@@ -16,9 +16,13 @@ pub enum ZkVmError {
     #[error("Execution failed: {0}")]
     ExecutionError(String),
 
-    /// Network (or RPC) error that can occur while using prover network.
-    #[error("Network error: {0}")]
-    NetworkRetryableError(String),
+    /// An error returned by a remote prover operation (submission, status
+    /// polling, or proof retrieval). Covers transport-level RPC failures
+    /// and operational errors that escape any backend-internal retry.
+    /// Carries no implicit retry contract — callers decide whether to
+    /// retry based on context.
+    #[error("Remote prover error: {0}")]
+    RemoteProverError(String),
 
     /// This error is returned when proof generation fails for any reason.
     #[error("Proof generation failed: {0}")]

--- a/zkaleido/src/remote_prover.rs
+++ b/zkaleido/src/remote_prover.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::{self, Debug, Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -55,7 +55,7 @@ pub enum RemoteProofFailureReason {
 }
 
 impl Display for RemoteProofFailureReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unexecutable => f.write_str("unexecutable"),
             Self::Unfulfillable => f.write_str("unfulfillable"),


### PR DESCRIPTION
## Description

The `start_proving` path in the SP1 remote prover mapped `.request()` errors through a `downcast_ref::<sp1_sdk::network::Error>()` to special-case the `RpcError(Status)` variant as `NetworkRetryableError`. That downcast never fires:

- `.request()` returns `anyhow::Result<B256>` ([`prove.rs:477`](https://github.com/succinctlabs/sp1/blob/d454975ac7c1126097e36eceda9bce2cb9899da4/crates/sdk/src/network/prove.rs#L477)).
- The underlying gRPC calls return `Result<_, tonic::Status>` and propagate through `?` directly into `anyhow::Error` — the `From<Status> for network::Error` impl in [`error.rs:41`](https://github.com/succinctlabs/sp1/blob/d454975ac7c1126097e36eceda9bce2cb9899da4/crates/sdk/src/network/error.rs#L41) is never on the conversion path because none of the call chain (`request_proof_impl`, `request_proof`, `with_retry`) returns `Result<_, network::Error>`.
- The SDK's own retry code confirms this by downcasting to `tonic::Status`, not `network::Error` ([`retry.rs:54`](https://github.com/succinctlabs/sp1/blob/d454975ac7c1126097e36eceda9bce2cb9899da4/crates/sdk/src/network/retry.rs#L54)).

The arm was effectively dead — every submission failure fell through to `ProofGenerationError`.

There is also limited value in re-classifying these errors at our layer: the SDK already wraps every RPC call in `with_retry` ([`client.rs:83`](https://github.com/succinctlabs/sp1/blob/d454975ac7c1126097e36eceda9bce2cb9899da4/crates/sdk/src/network/client.rs#L83)), which uses [`retry::retry_operation`](https://github.com/succinctlabs/sp1/blob/d454975ac7c1126097e36eceda9bce2cb9899da4/crates/sdk/src/network/retry.rs#L33) with an exponential backoff and a ~120s default budget. Transient `Unavailable`/`DeadlineExceeded`/`Internal`/`Aborted` codes and common transport errors are retried there before anything escapes to us.

This PR drops the broken downcast and maps all `.request()` failures to `NetworkRetryableError`, matching the polling calls (`get_status`, `get_proof`) already in the same impl. The caller can decide whether to retry the whole operation.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes to Reviewers

- The original intent appears to have been to distinguish transport-level failures from operational ones. If we want that distinction back, the precise way is to downcast to `tonic::Status` and classify by `status.code()` the way [`retry::retry_operation`](https://github.com/succinctlabs/sp1/blob/d454975ac7c1126097e36eceda9bce2cb9899da4/crates/sdk/src/network/retry.rs#L52-L124) does. I didn't do that here because (a) the SDK has already exhausted retries for those transients, and (b) nothing in this repo currently branches on `NetworkRetryableError` vs `ProofGenerationError`, so a more precise mapping has no consumer today.
- Pre-existing `clippy::absolute_paths` warnings in `zkaleido/src/remote_prover.rs:58` are unrelated to this change.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A
