### PR TITLE
feat(sp1-host): expose cuda feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7733,6 +7733,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp1-cuda"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400cfdb74fd455fac6f6a1d3a5c2ed1a603d6af44bc637718daf52a7c23f4ddf"
+dependencies = [
+ "bincode",
+ "bytes",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sp1-core-executor",
+ "sp1-core-machine",
+ "sp1-hypercube",
+ "sp1-primitives",
+ "sp1-prover",
+ "sp1-prover-types",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "sp1-curves"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8120,6 +8142,7 @@ dependencies = [
  "sp1-core-executor",
  "sp1-core-executor-runner",
  "sp1-core-machine",
+ "sp1-cuda",
  "sp1-hypercube",
  "sp1-primitives",
  "sp1-prover",

--- a/adapters/sp1/host/Cargo.toml
+++ b/adapters/sp1/host/Cargo.toml
@@ -24,3 +24,4 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }
 default = []
 ssz = ["zkaleido/ssz"]
 perf = ["sp1-sdk/profiling"]
+cuda = ["sp1-sdk/cuda"]


### PR DESCRIPTION
1. Problem

Alpen's SP1 prove-mode validation needed a way for downstream crates to request `sp1-sdk/cuda` through `zkaleido-sp1-host`.

The host crate exposed `default`, `perf`, and `ssz`, but not `cuda`, so downstream crates could not request the SP1 CUDA prover path through the normal dependency graph.

2. Change

This PR adds:

`cuda = ["sp1-sdk/cuda"]`

to `zkaleido-sp1-host`.

It also refreshes `Cargo.lock` so the feature-resolved dependency graph includes `sp1-cuda` and `--locked` validation works on this branch.

3. Preserved behavior

Nothing changes unless a downstream crate explicitly enables `zkaleido-sp1-host/cuda`.
Existing `default`, `perf`, and `ssz` behavior stays unchanged.

4. Validation

Public-branch validation

`cargo check -p zkaleido-sp1-host --features cuda --locked`

This passed in WSL on this branch.

Stacked downstream validation

This is the dependency-layer feature exposure used by the local Alpen CUDA validation behind:

`alpenlabs/alpen#1871`
`alpenlabs/alpen#1875`

Those Alpen PRs now describe that CUDA validation as stacked local evidence rather than overclaiming that the public Alpen branches reach it in isolation.

5. Review chain

This PR is the minimal host-level CUDA feature plumbing surfaced by the Alpen prove-mode work above.
The separate runtime program-id fix discovered during the same validation pass remains isolated in:

`alpenlabs/zkaleido#141`

AI usage disclosure

I used AI assistance for patch drafting, iteration, and PR text.
I reviewed and validated the final diff and verification notes manually.
