### PR TITLE
fix(sp1-host): contain upstream bytes32_raw packing bug

### DIFF
--- a/adapters/sp1/host/Cargo.toml
+++ b/adapters/sp1/host/Cargo.toml
@@ -16,6 +16,7 @@ async-trait.workspace = true
 bincode.workspace = true
 hex.workspace = true
 num-bigint.workspace = true
+p3-field = "0.3.3-succinct"
 serde.workspace = true
 sha2.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time"] }

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -3,6 +3,7 @@ use std::{
     future::{Future, IntoFuture},
 };
 
+use hex::FromHex;
 use sp1_core_executor::ExecutionReport;
 use sp1_sdk::{HashableKey, ProveRequest, Prover, ProvingKey, SP1ProofMode, env::EnvProver};
 use tokio::{
@@ -55,7 +56,7 @@ impl ZkVmExecutor for SP1Host {
     }
 
     fn program_id(&self) -> ProgramId {
-        ProgramId(self.proving_key.verifying_key().bytes32_raw())
+        ProgramId(program_id_from_vk_hex(&self.proving_key.verifying_key().bytes32()))
     }
 }
 
@@ -127,6 +128,13 @@ pub(crate) fn to_sp1_mode(proof_type: ProofType) -> SP1ProofMode {
         ProofType::Core => SP1ProofMode::Core,
         ProofType::Groth16 => SP1ProofMode::Groth16,
     }
+}
+
+fn program_id_from_vk_hex(bytes32: &str) -> [u8; 32] {
+    let hex = bytes32
+        .strip_prefix("0x")
+        .expect("SP1 bytes32 hash should be 0x-prefixed");
+    <[u8; 32]>::from_hex(hex).expect("SP1 bytes32 hash should decode into 32 raw bytes")
 }
 
 /// Drives `future` to completion from a synchronous context, regardless of
@@ -202,5 +210,20 @@ mod tests {
     fn ensure_clean_exit_accepts_success() {
         // Default ExecutionReport has exit_code = 0.
         assert!(ensure_clean_exit(&ExecutionReport::default()).is_ok());
+    }
+
+    #[test]
+    fn program_id_from_vk_hex_decodes_32_bytes() {
+        let program_id = program_id_from_vk_hex(
+            "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        );
+        assert_eq!(
+            program_id,
+            [
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+                0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+            ]
+        );
     }
 }

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -3,7 +3,8 @@ use std::{
     future::{Future, IntoFuture},
 };
 
-use hex::FromHex;
+use num_bigint::BigUint;
+use p3_field::PrimeField;
 use sp1_core_executor::ExecutionReport;
 use sp1_sdk::{HashableKey, ProveRequest, Prover, ProvingKey, SP1ProofMode, env::EnvProver};
 use tokio::{
@@ -56,7 +57,7 @@ impl ZkVmExecutor for SP1Host {
     }
 
     fn program_id(&self) -> ProgramId {
-        ProgramId(program_id_from_vk_hex(&self.proving_key.verifying_key().bytes32()))
+        ProgramId(program_id_from_vk(&self.proving_key))
     }
 }
 
@@ -130,11 +131,26 @@ pub(crate) fn to_sp1_mode(proof_type: ProofType) -> SP1ProofMode {
     }
 }
 
-fn program_id_from_vk_hex(bytes32: &str) -> [u8; 32] {
-    let hex = bytes32
-        .strip_prefix("0x")
-        .expect("SP1 bytes32 hash should be 0x-prefixed");
-    <[u8; 32]>::from_hex(hex).expect("SP1 bytes32 hash should decode into 32 raw bytes")
+fn program_id_from_vk(proving_key: &impl ProvingKey) -> [u8; 32] {
+    biguint_to_program_id(
+        proving_key
+            .verifying_key()
+            .hash_bn254()
+            .as_canonical_biguint(),
+    )
+}
+
+fn biguint_to_program_id(digest: BigUint) -> [u8; 32] {
+    let vkey_bytes = digest.to_bytes_be();
+    assert!(
+        vkey_bytes.len() <= 32,
+        "SP1 verifying key hash should fit in 32 bytes"
+    );
+
+    let mut result = [0u8; 32];
+    let start = result.len() - vkey_bytes.len();
+    result[start..].copy_from_slice(&vkey_bytes);
+    result
 }
 
 /// Drives `future` to completion from a synchronous context, regardless of
@@ -213,16 +229,60 @@ mod tests {
     }
 
     #[test]
-    fn program_id_from_vk_hex_decodes_32_bytes() {
-        let program_id = program_id_from_vk_hex(
-            "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    fn biguint_to_program_id_right_aligns_30_byte_value() {
+        let digest = BigUint::parse_bytes(
+            b"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e",
+            16,
+        )
+        .expect("valid hex");
+        let program_id = biguint_to_program_id(digest);
+
+        assert_eq!(program_id[..2], [0, 0]);
+        assert_eq!(
+            &program_id[2..],
+            &[
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+                0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+                0x1d, 0x1e,
+            ]
         );
+    }
+
+    #[test]
+    fn biguint_to_program_id_right_aligns_31_byte_value() {
+        let digest = BigUint::parse_bytes(
+            b"0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            16,
+        )
+        .expect("valid hex");
+        let program_id = biguint_to_program_id(digest);
+
+        assert_eq!(program_id[0], 0);
+        assert_eq!(
+            &program_id[1..],
+            &[
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+                0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+                0x1d, 0x1e, 0x1f,
+            ]
+        );
+    }
+
+    #[test]
+    fn biguint_to_program_id_preserves_32_byte_value() {
+        let digest = BigUint::parse_bytes(
+            b"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+            16,
+        )
+        .expect("valid hex");
+        let program_id = biguint_to_program_id(digest);
+
         assert_eq!(
             program_id,
             [
-                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
-                0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-                0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+                0x1c, 0x1d, 0x1e, 0x1f,
             ]
         );
     }


### PR DESCRIPTION
1. Problem

Alpen's `evm-ee-stf` SP1 prove path hit a runtime panic while deriving `ProgramId` from the proving key's verifying key.

The old PR replaced `bytes32_raw()` with a `bytes32()` hex round-trip. That avoided the panic locally, but it described the wrong failure mechanism.

The root cause sits upstream in `sp1-prover`'s `HashableKey::bytes32_raw()`. That helper computes the BN254 digest, converts it to big-endian bytes, then copies it into `result[1..]`. That hardcodes a 31-byte destination window for a value whose big-endian length is not guaranteed to be 31 bytes.

The reproduced failure came from that mismatch:
`copy_from_slice: source slice length (30) does not match destination slice length (31)`

2. Change

This PR no longer round-trips through `bytes32()`.

`zkaleido-sp1-host` now derives the program id from the same canonical source value that both `bytes32()` and `bytes32_raw()` start from:
`verifying_key().hash_bn254().as_canonical_biguint()`

It then right-aligns the big-endian bytes into a local `[u8; 32]` buffer.

That preserves the intended BN254 value while containing the bad upstream packing helper at the call site.

3. Why this shape

The bug is not in `ProgramId` decoding. The bug is in the upstream raw packing helper.

`zkaleido` cannot patch `sp1-prover` from this PR, so the right local fix is containment: use the same canonical digest, pack it correctly here, and stop calling the broken helper.

There is already an upstream SP1 PR for the helper in `succinctlabs/sp1#2508`. This PR keeps `zkaleido-sp1-host` safe until that upstream fix lands and propagates.

This PR stays separate from `#140`. `#140` exposes CUDA plumbing. This PR only contains the runtime bug in program-id derivation.

4. Tests

This PR adds coverage for the packing boundary that the old PR missed:

- 30-byte digest right-alignment
- 31-byte digest right-alignment
- 32-byte digest preservation

5. Validation

`cargo fmt --all --check`
`cargo test -p zkaleido-sp1-host biguint_to_program_id -- --nocapture`
`cargo test -p zkaleido-sp1-host ensure_clean_exit -- --nocapture`
`cargo check -p zkaleido-sp1-host`

All passed in WSL on this branch.

AI usage disclosure

I used AI assistance for patch drafting, iteration, and PR text.
I reviewed and validated the final diff and verification notes manually.
