### PR TITLE
refactor(zkaleido): drop redundant async_trait(?Send) on remote program trait

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,13 @@ jobs:
           cache-on-failure: true
       # Currently, sp1 and risc0 guest builds are skipped when it is invoked under clippy.
       # This makes the whole build of clippy fail, so we run clippy on adapters and examples.
+      # The core `zkaleido` crate has no guest-build deps, so it is linted directly as the
+      # primary crate (adapter builds only pull it in as a `--cap-lints allow` dependency,
+      # which hides its own lints).
+      - name: Run clippy on zkaleido
+        run: cargo clippy --manifest-path zkaleido/Cargo.toml --all-features -- -D warnings
+        env:
+          RUSTFLAGS: -D warnings
       - name: Run clippy on adapters/
         run: |
           find adapters/ -type f -name "Cargo.toml" \

--- a/adapters/sp1/host/src/prover.rs
+++ b/adapters/sp1/host/src/prover.rs
@@ -45,7 +45,7 @@ impl ZkVmExecutor for SP1Host {
     }
 
     fn save_trace(&self, trace_name: &str) {
-        let profiling_file_name = format!("{}_{:?}.trace_profile", trace_name, &self);
+        let profiling_file_name = format!("{}_{:?}.trace_profile", trace_name, self);
         // SAFETY: SP1 consumes this process-global trace setting from the
         // environment. Callers must configure tracing before concurrent prover
         // work starts.

--- a/runner/src/github.rs
+++ b/runner/src/github.rs
@@ -13,7 +13,7 @@ pub async fn post_to_github_pr(
     let client = Client::new();
 
     const BASE_URL: &str = "https://api.github.com/repos/alpenlabs/zkaleido";
-    let comments_url = format!("{}/issues/{}/comments", BASE_URL, &args.pr_number);
+    let comments_url = format!("{}/issues/{}/comments", BASE_URL, args.pr_number);
 
     // Get all comments on the PR
     let comments_response = set_github_headers(client.get(&comments_url), &args.github_token)

--- a/zkaleido/src/program.rs
+++ b/zkaleido/src/program.rs
@@ -1,9 +1,6 @@
 use std::env::var;
 
 #[cfg(feature = "remote-prover")]
-use async_trait::async_trait;
-
-#[cfg(feature = "remote-prover")]
 use crate::ZkVmRemoteHost;
 use crate::{
     ExecutionSummary, ProofReceiptWithMetadata, ProofType, PublicValues, ZkVmInputResult,
@@ -25,7 +22,11 @@ pub trait ZkVmProgram {
     /// necessary for the proof. It will be transformed into a ZkVM-specific format using a
     /// [`ZkVmInputBuilder`]. Implementers of this trait should define how the input
     /// structure is created, validated, and passed along to the ZkVM for proof generation.
-    type Input;
+    ///
+    /// `Send + Sync` lets `ZkVmRemoteProgram::start_proving` (under the `remote-prover`
+    /// feature) return a `Send` future, so remote proofs can be driven on a multithreaded
+    /// runtime. Every in-tree input is plain owned proof data that already satisfies it.
+    type Input: Send + Sync;
 
     /// Represents the final, verifiable output produced by the program.
     ///
@@ -166,9 +167,15 @@ impl<T: ZkVmProgram> ZkVmProgramPerf for T {}
 /// to initiate asynchronous proof generation via the `start_proving` method, and later retrieve the
 /// proof once it is ready.
 #[cfg(feature = "remote-prover")]
-#[async_trait(?Send)]
 pub trait ZkVmRemoteProgram: ZkVmProgram {
     /// Starts the proving process using any zkVM remote host, returning a typed proof ID.
+    // `async_fn_in_trait` fires because a native async fn in a trait carries no `Send` bound in
+    // its signature. The future is nonetheless `Send`: it captures `&Self::Input`, which is
+    // `Send` because `ZkVmProgram::Input: Send + Sync`, and awaits the now-`Send` host future.
+    // Concrete callers therefore get a `Send`, spawnable future via auto-trait leakage; only a
+    // purely generic caller would be unable to name the bound, and none exists. Suppress rather
+    // than desugar to `fn -> impl Future + Send` to keep the `async fn` body.
+    #[expect(async_fn_in_trait, reason = "future is Send via Input: Send + Sync, just not named")]
     async fn start_proving<'a, H>(input: &'a Self::Input, host: &H) -> ZkVmResult<H::ProofId>
     where
         H: ZkVmRemoteHost,
@@ -187,5 +194,4 @@ pub trait ZkVmRemoteProgram: ZkVmProgram {
 /// automatically satisfy the `ZkVmRemoteProgram` trait without requiring explicit implementations.
 /// The default `start_proving` method provided by the trait is sufficient for most use cases.
 #[cfg(feature = "remote-prover")]
-#[async_trait(?Send)]
 impl<T: ZkVmProgram> ZkVmRemoteProgram for T {}

--- a/zkaleido/src/program.rs
+++ b/zkaleido/src/program.rs
@@ -1,4 +1,4 @@
-use std::env::var;
+use std::{env::var, future::Future};
 
 #[cfg(feature = "remote-prover")]
 use crate::ZkVmRemoteHost;
@@ -169,25 +169,28 @@ impl<T: ZkVmProgram> ZkVmProgramPerf for T {}
 #[cfg(feature = "remote-prover")]
 pub trait ZkVmRemoteProgram: ZkVmProgram {
     /// Starts the proving process using any zkVM remote host, returning a typed proof ID.
-    // `async_fn_in_trait` fires because a native async fn in a trait carries no `Send` bound in
-    // its signature. The future is nonetheless `Send`: it captures `&Self::Input`, which is
-    // `Send` because `ZkVmProgram::Input: Send + Sync`, and awaits the now-`Send` host future.
-    // Concrete callers therefore get a `Send`, spawnable future via auto-trait leakage; only a
-    // purely generic caller would be unable to name the bound, and none exists. Suppress rather
-    // than desugar to `fn -> impl Future + Send` to keep the `async fn` body.
-    #[expect(
-        async_fn_in_trait,
-        reason = "future is Send via Input: Send + Sync, just not named"
-    )]
-    async fn start_proving<'a, H>(input: &'a Self::Input, host: &H) -> ZkVmResult<H::ProofId>
+    ///
+    /// The returned future is explicitly `Send` so consumers (e.g. `prover-core`/paas) can drive
+    /// remote proofs on a multithreaded runtime and `tokio::spawn` them, instead of confining them
+    /// to a `LocalSet`. It is `Send` because it only borrows `&Self::Input` (`Send` via
+    /// `ZkVmProgram::Input: Send + Sync`) and `&H` (`Send` via `ZkVmHost: …: ZkVmExecutor: Sync`),
+    /// and awaits the host's `Send` future. We spell out `-> impl Future + Send` rather than use an
+    /// `async fn`, whose desugaring leaves the `Send` bound unnamed and therefore unusable by
+    /// generic callers.
+    fn start_proving<'a, H>(
+        input: &'a Self::Input,
+        host: &H,
+    ) -> impl Future<Output = ZkVmResult<H::ProofId>> + Send
     where
         H: ZkVmRemoteHost,
         H::Input<'a>: ZkVmInputBuilder<'a>,
     {
-        // Prepare the input using the host's input builder.
-        let zkvm_input = Self::prepare_input::<H::Input<'a>>(input)?;
+        async move {
+            // Prepare the input using the host's input builder.
+            let zkvm_input = Self::prepare_input::<H::Input<'a>>(input)?;
 
-        host.start_proving(zkvm_input, Self::proof_type()).await
+            host.start_proving(zkvm_input, Self::proof_type()).await
+        }
     }
 }
 

--- a/zkaleido/src/program.rs
+++ b/zkaleido/src/program.rs
@@ -175,7 +175,10 @@ pub trait ZkVmRemoteProgram: ZkVmProgram {
     // Concrete callers therefore get a `Send`, spawnable future via auto-trait leakage; only a
     // purely generic caller would be unable to name the bound, and none exists. Suppress rather
     // than desugar to `fn -> impl Future + Send` to keep the `async fn` body.
-    #[expect(async_fn_in_trait, reason = "future is Send via Input: Send + Sync, just not named")]
+    #[expect(
+        async_fn_in_trait,
+        reason = "future is Send via Input: Send + Sync, just not named"
+    )]
     async fn start_proving<'a, H>(input: &'a Self::Input, host: &H) -> ZkVmResult<H::ProofId>
     where
         H: ZkVmRemoteHost,

--- a/zkaleido/src/remote_prover.rs
+++ b/zkaleido/src/remote_prover.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::{self, Debug, Display, Formatter};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -55,7 +55,7 @@ pub enum RemoteProofFailureReason {
 }
 
 impl Display for RemoteProofFailureReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unexecutable => f.write_str("unexecutable"),
             Self::Unfulfillable => f.write_str("unfulfillable"),

--- a/zkaleido/src/remote_prover.rs
+++ b/zkaleido/src/remote_prover.rs
@@ -79,7 +79,11 @@ pub trait ZkVmRemoteProver: ZkVmProver {
     /// Must be displayable for logging, cloneable for repeated status queries, and
     /// convertible to/from `Vec<u8>` for persistent storage (e.g. in a database) so
     /// that proof status polling can be resumed across restarts.
-    type ProofId: Debug + Display + Clone + Into<Vec<u8>> + TryFrom<Vec<u8>> + 'static;
+    ///
+    /// `Send + Sync` is required so the ID can be carried across `.await` points and
+    /// shared between tasks by async consumers driving proofs on a multithreaded
+    /// executor, without each consumer having to restate the bound.
+    type ProofId: Debug + Display + Clone + Into<Vec<u8>> + TryFrom<Vec<u8>> + Send + Sync + 'static;
 
     /// Starts the proving process for the given input and proof type.
     ///


### PR DESCRIPTION
## Description

PR #138 tightened `ZkVmRemoteProver` to *require* `Send` futures (dropping its `#[async_trait(?Send)]` opt-out) so downstream consumers could `tokio::spawn` proof workers on a multi-threaded runtime without a `LocalSet`/dedicated-thread wrapper. But it left the `ZkVmRemoteProgram` convenience wrapper — and its blanket impl — still annotated `#[async_trait(?Send)]`. That macro boxes the wrapper's future as `Pin<Box<dyn Future>>` with no `Send`, so the wrapper stayed `!Send` even though the host method it calls is now `Send` — forcing the downstream worker to inline `prepare_input` + `host.start_proving` to dodge it.

This PR drops that macro on `ZkVmRemoteProgram::start_proving` for a native `async fn`. The wrapper future captures `&Self::Input`, so it is `Send` only when the input is `Sync`; this PR bounds `ZkVmProgram::Input: Send + Sync` to guarantee it (every in-tree and downstream input is plain owned proof data that already satisfies the bound — this matches the `type Input: Send + Sync` fix already noted as planned in alpen's prover-core README). With that bound the future is `Send` for every program, so the downstream worker can call `ZkVmRemoteProgram::start_proving` directly (auto-trait leakage gives concrete callers a `Send`, spawnable future) instead of inlining around it.

This PR also promotes `Send + Sync` onto the `ZkVmRemoteProver::ProofId` associated type. The concrete IDs (`Sp1ProofId`, `NativeProofId`) already satisfy it, and async consumers carry the typed ID across `.await` points and between tasks — so requiring it once on the trait spares every consumer from restating `H::ProofId: Send + Sync` on each impl block.

Finally, the clippy job now lints the core `zkaleido` crate directly. Previously clippy only ran over `adapters/` and `examples/`, where `zkaleido` is pulled in as a dependency and compiled with `--cap-lints allow`, so its own lints were never enforced. `zkaleido` has no guest-build deps, so it can be linted as a primary crate.

### Type of Change

- [x] Refactor
- [x] Breaking change (`ZkVmProgram::Input` now requires `Send + Sync`)
- [x] CI

## Notes to Reviewers

**Open question — how should we handle `async_fn_in_trait`?** A native `async fn` in a trait carries no `Send` bound in its signature, so linting `zkaleido` directly surfaces `async_fn_in_trait` on `start_proving`. The future is nonetheless `Send` (it captures `&Self::Input`, which is `Send` via `Input: Send + Sync`, and awaits the now-`Send` host future), and concrete callers get that `Send` future via auto-trait leakage — only a purely generic caller would be unable to *name* the bound, and none exists. There are two ways to make CI green, and I went with the first; **please weigh in on which you prefer:**

1. **(current) Keep `async fn`, suppress the lint** with `#[expect(async_fn_in_trait, reason = "...")]`. Keeps the plain `async fn` body; the cost is an `#[expect]` attribute and that generic callers can't name `Send`.
   ```rust
   #[expect(async_fn_in_trait, reason = "future is Send via Input: Send + Sync, just not named")]
   async fn start_proving<'a, H>(input: &'a Self::Input, host: &H) -> ZkVmResult<H::ProofId>
   where H: ZkVmRemoteHost, H::Input<'a>: ZkVmInputBuilder<'a> {
       let zkvm_input = Self::prepare_input::<H::Input<'a>>(input)?;
       host.start_proving(zkvm_input, Self::proof_type()).await
   }
   ```
2. **Desugar to `fn -> impl Future + Send`.** No suppression, and the `Send` guarantee is named in the signature (generic callers can rely on it); the cost is an explicit `async move { … }` wrapper in the body.
   ```rust
   fn start_proving<'a, H>(input: &'a Self::Input, host: &'a H)
       -> impl Future<Output = ZkVmResult<H::ProofId>> + Send
   where H: ZkVmRemoteHost, H::Input<'a>: ZkVmInputBuilder<'a> {
       async move {
           let zkvm_input = Self::prepare_input::<H::Input<'a>>(input)?;
           host.start_proving(zkvm_input, Self::proof_type()).await
       }
   }
   ```

`ZkVmProgram::Input: Send + Sync` is the only externally-visible breaking change. All in-tree input types (`u32`, `FibCompositionInput`, `SP1Groth16VerifyInput`, `SchnorrSigInput`) and the downstream ones (`CheckpointProverInput`, `EeAcctProofInput`, `RuntimeInput`, …) are plain owned data that already satisfy it.

## Checklist

- [x] I have performed a self-review of my code.
- [x] New and existing tests pass with my changes.

## Related Issues

Follow-up to #138.
