### PR TITLE
feat(sp1-groth16): expose Groth16Proof and its serialization

### DIFF
--- a/adapters/sp1/groth16-verifier/src/lib.rs
+++ b/adapters/sp1/groth16-verifier/src/lib.rs
@@ -12,11 +12,14 @@
 //!
 //! - [`SP1Groth16Verifier`] — the verifier itself, with `load` / `verify` / canonical byte
 //!   serialization (`to_compressed_bytes`, `to_uncompressed_bytes`, `parse`).
-//! - [`Sp1Groth16Proof`] — parses the on-wire byte format into the optional prefix fields.
+//! - [`Sp1Groth16Proof`] — parses the on-wire byte format into the optional prefix fields and the
+//!   underlying [`Groth16Proof`].
+//! - [`Groth16Proof`] — the underlying Groth16 proof carried by [`Sp1Groth16Proof`], with
+//!   GNARK-compressed and uncompressed byte (de)serialization.
 //! - [`Sp1Groth16Error`] — error type returned by the inherent methods on the two types above.
 //!
-//! Everything else (the inner Groth16 types, the algebraic pairing routine, size constants)
-//! is an implementation detail and not part of the stable surface.
+//! Everything else (the algebraic pairing routine, size constants) is an implementation detail and
+//! not part of the stable surface.
 //!
 //! # The "fold fixed inputs into K0" optimisation
 //!
@@ -65,4 +68,5 @@ mod verifier;
 
 pub use error::Sp1Groth16Error;
 pub use proof::Sp1Groth16Proof;
+pub use types::proof::Groth16Proof;
 pub use verifier::SP1Groth16Verifier;

--- a/adapters/sp1/groth16-verifier/src/proof.rs
+++ b/adapters/sp1/groth16-verifier/src/proof.rs
@@ -47,10 +47,9 @@ pub struct Sp1Groth16Proof {
     pub vk_root: Option<[u8; 32]>,
     /// SP1 proof nonce (SP1 v6+).
     pub proof_nonce: Option<[u8; 32]>,
-    /// The underlying Groth16 proof. Crate-private because [`Groth16Proof`] is not part of
-    /// this crate's public surface; downstream callers verify via
+    /// The underlying Groth16 proof. Downstream callers verify via
     /// [`SP1Groth16Verifier::verify_parsed`](crate::SP1Groth16Verifier::verify_parsed).
-    pub(crate) proof: Groth16Proof,
+    pub proof: Groth16Proof,
 }
 
 impl From<Groth16Proof> for Sp1Groth16Proof {

--- a/adapters/sp1/groth16-verifier/src/types/proof.rs
+++ b/adapters/sp1/groth16-verifier/src/types/proof.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Proof for the Groth16 verification.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct Groth16Proof {
+pub struct Groth16Proof {
     pub(crate) ar: SAffineG1,
     pub(crate) krs: SAffineG1,
     pub(crate) bs: SAffineG2,
@@ -27,7 +27,7 @@ impl Groth16Proof {
     /// - bytes 192..256: uncompressed G1 point `K·R·S`
     ///
     /// Returns a `Groth16Proof` containing affine points `(ar, bs, krs)`.
-    pub(crate) fn from_uncompressed_bytes(buffer: &[u8]) -> Result<Groth16Proof, Sp1Groth16Error> {
+    pub fn from_uncompressed_bytes(buffer: &[u8]) -> Result<Groth16Proof, Sp1Groth16Error> {
         if buffer.len() != GROTH16_PROOF_UNCOMPRESSED_SIZE {
             return Err(Sp1Groth16Error::Serialization(
                 BufferLengthError {
@@ -52,7 +52,7 @@ impl Groth16Proof {
     }
 
     /// Deserialize from GNARK-compressed bytes (128 bytes).
-    pub(crate) fn from_gnark_compressed_bytes(bytes: &[u8]) -> Result<Self, Sp1Groth16Error> {
+    pub fn from_gnark_compressed_bytes(bytes: &[u8]) -> Result<Self, Sp1Groth16Error> {
         if bytes.len() != GROTH16_PROOF_COMPRESSED_SIZE {
             return Err(Sp1Groth16Error::Serialization(
                 BufferLengthError {
@@ -85,8 +85,7 @@ impl Groth16Proof {
     /// - bytes 96..128:  GNARK-compressed G1 point `K·R·S`
     ///
     /// Note: This is more compact than GNARK's uncompressed format (256 bytes).
-    #[cfg(test)]
-    pub(crate) fn to_gnark_compressed_bytes(&self) -> [u8; GROTH16_PROOF_COMPRESSED_SIZE] {
+    pub fn to_gnark_compressed_bytes(&self) -> [u8; GROTH16_PROOF_COMPRESSED_SIZE] {
         let mut bytes = [0u8; GROTH16_PROOF_COMPRESSED_SIZE];
 
         // Serialize ar (G1 GNARK-compressed)
@@ -106,8 +105,7 @@ impl Groth16Proof {
     /// Serialize to uncompressed bytes (256 bytes: 64 + 128 + 64).
     ///
     /// This is equivalent to GNARK's format.
-    #[cfg(test)]
-    pub(crate) fn to_uncompressed_bytes(&self) -> [u8; GROTH16_PROOF_UNCOMPRESSED_SIZE] {
+    pub fn to_uncompressed_bytes(&self) -> [u8; GROTH16_PROOF_UNCOMPRESSED_SIZE] {
         let mut bytes = [0u8; GROTH16_PROOF_UNCOMPRESSED_SIZE];
 
         // Serialize ar (G1 uncompressed)


### PR DESCRIPTION
## Description

`Sp1Groth16Proof` parses an SP1 on-wire proof into its optional prefix fields plus the underlying Groth16 proof, but that inner `Groth16Proof` was crate-private and the `proof` field was `pub(crate)`, so downstream code could only ever feed the whole `Sp1Groth16Proof` back into the verifier. strata-bridge needs to hold and re-serialize the inner proof on its own; this surfaced while bumping zkaleido in alpenlabs/strata-bridge#638.

This re-exports `Groth16Proof`, makes `Sp1Groth16Proof::proof` public, and exposes the GNARK-compressed/uncompressed byte (de)serialization on `Groth16Proof`. The `to_*` serializers were previously `#[cfg(test)]`-only, so consumers had no way to produce the compact compressed encoding they want — they are now un-gated and public, giving a symmetric, usable round-trip (`from_gnark_compressed_bytes` / `to_gnark_compressed_bytes` and the uncompressed pair).

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)

## Notes to Reviewers

No behavior change — purely a visibility widening plus dropping a `#[cfg(test)]` gate. The inner G1/G2 serializers these delegate to were already `pub(crate)` and compiled in non-test builds, so un-gating the proof-level `to_*` methods needed no further changes.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Needed by alpenlabs/strata-bridge#638.
