### PR TITLE
fix(sp1-groth16): use a verifier-specific error when VK parsing fails

### DIFF
--- a/adapters/sp1/groth16-verifier/src/error.rs
+++ b/adapters/sp1/groth16-verifier/src/error.rs
@@ -34,6 +34,16 @@ pub struct InvalidProofFormatError {
     pub actual: usize,
 }
 
+/// Error for unsupported or invalid verifier (verifying key) format.
+///
+/// Raised when a serialized verifier's byte length does not match either the compressed or the
+/// uncompressed canonical encoding.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[error("Invalid SP1 Groth16 verifier length: got {actual} bytes")]
+pub struct InvalidVerifierFormatError {
+    pub actual: usize,
+}
+
 /// Error for Groth16 public input count mismatches.
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 #[error("Invalid public input count: expected {expected}, got {actual}")]
@@ -66,6 +76,10 @@ pub enum SerializationError {
     /// Proof format is invalid or unsupported.
     #[error(transparent)]
     InvalidProofFormat(#[from] InvalidProofFormatError),
+
+    /// Verifier (verifying key) format is invalid or unsupported.
+    #[error(transparent)]
+    InvalidVerifierFormat(#[from] InvalidVerifierFormatError),
 
     /// Elliptic curve point is invalid.
     #[error(transparent)]

--- a/adapters/sp1/groth16-verifier/src/verifier.rs
+++ b/adapters/sp1/groth16-verifier/src/verifier.rs
@@ -15,7 +15,7 @@ use zkaleido::{ProofReceipt, ZkVmError, ZkVmResult, ZkVmVerifier};
 use crate::{
     Sp1Groth16Proof,
     error::{
-        BufferLengthError, InvalidDataFormatError, InvalidProofFormatError, SerializationError,
+        BufferLengthError, InvalidDataFormatError, InvalidVerifierFormatError, SerializationError,
         Sp1Groth16Error,
     },
     hashes::{blake3_to_fr, sha256_to_fr},
@@ -330,7 +330,7 @@ impl SP1Groth16Verifier {
     /// Detection is structural: both encodings store `num_k` at a known offset within the VK
     /// header, so this function peeks at each candidate offset, computes the implied total
     /// length, and dispatches to the parser whose computed length matches the input buffer.
-    /// If neither matches, an `InvalidProofFormatError` is returned without invoking either
+    /// If neither matches, an `InvalidVerifierFormatError` is returned without invoking either
     /// parser; if exactly one matches, that parser's error (if any) is the one surfaced — so
     /// callers don't see a misleading "wrong format" error from the fallback.
     ///
@@ -350,7 +350,7 @@ impl SP1Groth16Verifier {
                 Self::from_uncompressed_bytes(bytes).or_else(|_| Self::from_compressed_bytes(bytes))
             }
             (false, false) => Err(Sp1Groth16Error::Serialization(
-                InvalidProofFormatError {
+                InvalidVerifierFormatError {
                     actual: bytes.len(),
                 }
                 .into(),
@@ -871,13 +871,13 @@ mod tests {
     #[test]
     fn test_verifier_parse_rejects_garbage() {
         // A buffer matching neither encoding's length should fail to parse with
-        // `InvalidProofFormat`. 17 bytes is below every plausible header size, so neither
+        // `InvalidVerifierFormat`. 17 bytes is below every plausible header size, so neither
         // candidate length computation succeeds.
         let garbage = vec![0xAAu8; 17];
         let err = SP1Groth16Verifier::parse(&garbage).unwrap_err();
         assert!(matches!(
             err,
-            Sp1Groth16Error::Serialization(SerializationError::InvalidProofFormat(_))
+            Sp1Groth16Error::Serialization(SerializationError::InvalidVerifierFormat(_))
         ));
     }
 


### PR DESCRIPTION
## Description

`SP1Groth16Verifier::parse` returned an `InvalidProofFormatError` when a buffer matched neither the compressed nor the uncompressed verifying-key encoding. That error type is meant for SP1 *proofs* — its `Display` renders "Invalid SP1 Groth16 proof length: got N bytes" — so a failed *verifier* (verifying key) decode surfaced a misleading proof-format error to callers.

This adds a dedicated `InvalidVerifierFormatError` (parallel to the existing `InvalidProofFormatError`), wires it into `SerializationError`, and returns it from `parse` so the error accurately names what failed.

I also audited the rest of the crate's error sites: the remaining `InvalidProofFormatError` use is in `Sp1Groth16Proof::parse` (correct — that path parses a proof), and all `BufferLengthError` `context` strings already match their subjects (VK/verifier/point/proof). No other mismatches found.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes to Reviewers

`InvalidVerifierFormatError` is `pub` in the `error` module, consistent with the other error structs (only `Sp1Groth16Error` is re-exported at the crate root). The existing `test_verifier_parse_rejects_garbage` was updated to assert the new variant.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
