### PR TITLE
fix(sp1-groth16): validate serde proof points

### DIFF
--- a/adapters/sp1/groth16-verifier/src/serde.rs
+++ b/adapters/sp1/groth16-verifier/src/serde.rs
@@ -18,7 +18,7 @@ use serde::{
 };
 
 use crate::{
-    error::{BufferLengthError, InvalidDataFormatError, InvalidPointError, SerializationError},
+    error::{BufferLengthError, InvalidDataFormatError, SerializationError},
     types::{
         constant::{FQ_SIZE, G1_UNCOMPRESSED_SIZE, G2_UNCOMPRESSED_SIZE},
         g1::SAffineG1,
@@ -68,11 +68,7 @@ impl TryFrom<SAffineG1Helper> for SAffineG1 {
     fn try_from(value: SAffineG1Helper) -> Result<Self, Self::Error> {
         let x = deserialize_fq_from_hex(&value.x)?;
         let y = deserialize_fq_from_hex(&value.y)?;
-        let z = Fq::one();
-
-        let projective = G1::new(x, y, z);
-
-        let g1 = bn::AffineG1::from_jacobian(projective).ok_or(InvalidPointError)?;
+        let g1 = bn::AffineG1::new(x, y)?;
         Ok(SAffineG1(g1))
     }
 }
@@ -137,11 +133,7 @@ impl TryFrom<SAffineG2Helper> for SAffineG2 {
     fn try_from(value: SAffineG2Helper) -> Result<Self, Self::Error> {
         let x = deserialize_fq2_from_hex(&value.x)?;
         let y = deserialize_fq2_from_hex(&value.y)?;
-        let z = Fq2::one();
-
-        let projective = G2::new(x, y, z);
-
-        let g2 = bn::AffineG2::from_jacobian(projective).ok_or(InvalidPointError)?;
+        let g2 = bn::AffineG2::new(x, y)?;
         Ok(SAffineG2(g2))
     }
 }

--- a/adapters/sp1/groth16-verifier/src/serde.rs
+++ b/adapters/sp1/groth16-verifier/src/serde.rs
@@ -410,7 +410,20 @@ fn hex_string_to_fq_bytes(hex_str: &str) -> Result<[u8; FQ_SIZE], SerializationE
 mod tests {
     use sp1_verifier::GROTH16_VK_BYTES;
 
-    use crate::types::vk::Groth16VerifyingKey;
+    use crate::types::{proof::Groth16Proof, vk::Groth16VerifyingKey};
+
+    #[test]
+    fn test_groth16_proof_json_rejects_invalid_points() {
+        let zero = format!("0x{}", "00".repeat(32));
+        let g1 = serde_json::json!({ "x": zero, "y": zero });
+        let fq2 = serde_json::json!({ "real": zero, "imaginary": zero });
+        let g2 = serde_json::json!({ "x": fq2, "y": fq2 });
+        let proof = serde_json::json!({ "ar": g1, "krs": g1, "bs": g2 });
+
+        let result = serde_json::from_value::<Groth16Proof>(proof);
+
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_vk_serde_json() {


### PR DESCRIPTION
### Motivation
- The human-readable serde deserialization path constructed G1/G2 points via unchecked projective-to-affine conversion, which could allow invalid curve points into a public `Groth16Proof` and reach the pairing verifier. 
- The change restores the same point validation semantics used by the byte parsers to prevent attacker-controlled malformed points from being accepted.

### Description
- Replaced unchecked projective construction + `Affine::from_jacobian` with the checked constructors `bn::AffineG1::new(x, y)?` and `bn::AffineG2::new(x, y)?` in the human-readable `TryFrom` implementations for `SAffineG1` and `SAffineG2` in `adapters/sp1/groth16-verifier/src/serde.rs`.
- Removed the now-unused `InvalidPointError` import from `serde.rs` and adjusted imports accordingly.
- Added a regression unit test `test_groth16_proof_json_rejects_invalid_points` that attempts to deserialize an all-zero JSON `Groth16Proof` and asserts deserialization fails.
- Changes are limited to `adapters/sp1/groth16-verifier/src/serde.rs` and preserve existing binary (byte) deserialization behavior.

### Testing
- Ran `cargo test -p zkaleido-sp1-groth16-verifier --features serde test_groth16_proof_json_rejects_invalid_points`, which passed. 
- Ran the full serde-enabled test suite `cargo test -p zkaleido-sp1-groth16-verifier --features serde`, which completed successfully with all tests passing (33 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a472f583508832c9870fc1f8b106676)