### PR TITLE
fix(sp1-groth16): reject infinity flag in compressed G2 decoding

### DIFF
--- a/adapters/sp1/groth16-verifier/src/types/constant.rs
+++ b/adapters/sp1/groth16-verifier/src/types/constant.rs
@@ -10,19 +10,19 @@ pub(crate) const VK_HASH_PREFIX_LENGTH: usize = 4;
 /// SP1 program exit code committed to a successful execution (32 zero bytes).
 pub(crate) const SUCCESS_EXIT_CODE: [u8; 32] = [0u8; 32];
 
-/// Mask to clear out the two most significant bits when reconstructing an Fq element
-/// from a compressed representation.
+/// Mask to clear out the two most significant bits when reconstructing an Fq (G1) or
+/// Fq2 (G2) element from a compressed representation.
 ///
-/// These two bits encode the `CompressedPointFlag` for G1 points (positive, negative, or infinity).
-/// Gnark (and arkworks) use the 2 most significant bits to encode the flag for a compressed
-/// G1 point.
+/// These two bits encode the `CompressedPointFlag` for both G1 and G2 points (positive,
+/// negative, or infinity). Gnark (and arkworks) use the 2 most significant bits to encode
+/// the flag for a compressed point.
 /// https://github.com/Consensys/gnark-crypto/blob/a7d721497f2a98b1f292886bb685fd3c5a90f930/ecc/bn254/marshal.go#L32-L42
 pub(crate) const MASK: u8 = 0b11 << 6;
 
-/// Flag indicating the “positive” y‐coordinate branch of a compressed G1 point.
+/// Flag indicating the “positive” y‐coordinate branch of a compressed G1 or G2 point.
 pub(crate) const COMPRESSED_POSITIVE: u8 = 0b10 << 6;
 
-/// Flag indicating the “negative” y‐coordinate branch of a compressed G1 point.
+/// Flag indicating the “negative” y‐coordinate branch of a compressed G1 or G2 point.
 pub(crate) const COMPRESSED_NEGATIVE: u8 = 0b11 << 6;
 
 /// Size of a u32 in bytes (for num_k)

--- a/adapters/sp1/groth16-verifier/src/types/constant.rs
+++ b/adapters/sp1/groth16-verifier/src/types/constant.rs
@@ -25,9 +25,6 @@ pub(crate) const COMPRESSED_POSITIVE: u8 = 0b10 << 6;
 /// Flag indicating the “negative” y‐coordinate branch of a compressed G1 point.
 pub(crate) const COMPRESSED_NEGATIVE: u8 = 0b11 << 6;
 
-/// Flag indicating the "point at infinity" in a compressed G2 representation.
-pub(crate) const COMPRESSED_INFINITY: u8 = 0b01 << 6;
-
 /// Size of a u32 in bytes (for num_k)
 pub(crate) const U32_SIZE: usize = size_of::<u32>();
 

--- a/adapters/sp1/groth16-verifier/src/types/g2.rs
+++ b/adapters/sp1/groth16-verifier/src/types/g2.rs
@@ -29,8 +29,9 @@ impl SAffineG2 {
     /// Deserialize from GNARK-compressed bytes (64 bytes: x-coordinate (Fq2) with flag bits).
     ///
     /// Uses the GNARK compression scheme where the first two bits of the first byte encode a flag:
-    /// - `COMPRESSED_INFINITY`: the point at infinity in G2.
     /// - `COMPRESSED_POSITIVE` / `COMPRESSED_NEGATIVE`: choose the appropriate y‐coordinate branch.
+    /// - `COMPRESSED_INFINITY`: rejected. The point at infinity is not representable as an affine
+    ///   point and never appears in a valid Groth16 proof or verifying key.
     pub(crate) fn from_gnark_compressed_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
         if bytes.len() != G2_COMPRESSED_SIZE {
             return Err(BufferLengthError {
@@ -44,11 +45,10 @@ impl SAffineG2 {
         // Extract the two-bit flag from the first byte.
         let flag = bytes[0] & MASK;
 
-        // If the flag indicates infinity, return the point at infinity in G2.
+        // Reject the infinity flag: the point at infinity has no affine representation, and
+        // decoding it to any concrete point would silently substitute a different point.
         if flag == COMPRESSED_INFINITY {
-            return Ok(SAffineG2(
-                AffineG2::from_jacobian(G2::one()).ok_or(InvalidPointError)?,
-            ));
+            return Err(InvalidDataFormatError.into());
         }
 
         // Reconstruct x1 (imaginary part of Fq2) with flags cleared.
@@ -209,7 +209,20 @@ impl fmt::Debug for SAffineG2 {
 mod tests {
     use bn::{AffineG2, G2, Group};
 
-    use crate::types::g2::SAffineG2;
+    use crate::types::{
+        constant::{COMPRESSED_INFINITY, G2_COMPRESSED_SIZE},
+        g2::SAffineG2,
+    };
+
+    #[test]
+    fn test_compressed_g2_rejects_infinity_flag() {
+        let mut bytes = [0u8; G2_COMPRESSED_SIZE];
+        bytes[0] = COMPRESSED_INFINITY;
+
+        let result = SAffineG2::from_gnark_compressed_bytes(&bytes);
+
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_uncompressed_g2_roundtrip() {

--- a/adapters/sp1/groth16-verifier/src/types/g2.rs
+++ b/adapters/sp1/groth16-verifier/src/types/g2.rs
@@ -5,7 +5,7 @@ use bn::{AffineG2, Fq, Fq2, G2, Group};
 use crate::{
     error::{BufferLengthError, InvalidDataFormatError, InvalidPointError, SerializationError},
     types::constant::{
-        COMPRESSED_INFINITY, COMPRESSED_NEGATIVE, COMPRESSED_POSITIVE, FQ_SIZE, G2_COMPRESSED_SIZE,
+        COMPRESSED_NEGATIVE, COMPRESSED_POSITIVE, FQ_SIZE, G2_COMPRESSED_SIZE,
         G2_UNCOMPRESSED_SIZE, MASK,
     },
 };
@@ -29,9 +29,11 @@ impl SAffineG2 {
     /// Deserialize from GNARK-compressed bytes (64 bytes: x-coordinate (Fq2) with flag bits).
     ///
     /// Uses the GNARK compression scheme where the first two bits of the first byte encode a flag:
-    /// - `COMPRESSED_POSITIVE` / `COMPRESSED_NEGATIVE`: choose the appropriate y‐coordinate branch.
-    /// - `COMPRESSED_INFINITY`: rejected. The point at infinity is not representable as an affine
-    ///   point and never appears in a valid Groth16 proof or verifying key.
+    /// - `COMPRESSED_POSITIVE`: use the lexicographically smaller of (y, -y) as y.
+    /// - `COMPRESSED_NEGATIVE`: use the lexicographically larger of (y, -y) as y.
+    ///
+    /// Any other flag value, including `COMPRESSED_INFINITY`, is rejected: the point at infinity
+    /// has no affine representation and never appears in a valid Groth16 proof or verifying key.
     pub(crate) fn from_gnark_compressed_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
         if bytes.len() != G2_COMPRESSED_SIZE {
             return Err(BufferLengthError {
@@ -44,12 +46,6 @@ impl SAffineG2 {
 
         // Extract the two-bit flag from the first byte.
         let flag = bytes[0] & MASK;
-
-        // Reject the infinity flag: the point at infinity has no affine representation, and
-        // decoding it to any concrete point would silently substitute a different point.
-        if flag == COMPRESSED_INFINITY {
-            return Err(InvalidDataFormatError.into());
-        }
 
         // Reconstruct x1 (imaginary part of Fq2) with flags cleared.
         let mut x1_bytes = [0u8; FQ_SIZE];
@@ -209,15 +205,24 @@ impl fmt::Debug for SAffineG2 {
 mod tests {
     use bn::{AffineG2, G2, Group};
 
-    use crate::types::{
-        constant::{COMPRESSED_INFINITY, G2_COMPRESSED_SIZE},
-        g2::SAffineG2,
-    };
+    use crate::types::{constant::MASK, g2::SAffineG2};
+
+    // Gnark's compressed-point flag value for "point at infinity" (see `MASK` for the
+    // encoding). Declared here rather than in `constant.rs` since only this test needs it.
+    const COMPRESSED_INFINITY: u8 = 0b01 << 6;
 
     #[test]
     fn test_compressed_g2_rejects_infinity_flag() {
-        let mut bytes = [0u8; G2_COMPRESSED_SIZE];
-        bytes[0] = COMPRESSED_INFINITY;
+        // Use a genuinely on-curve x-coordinate (from a real point) so this exercises the
+        // flag-rejection branch specifically, rather than incidentally failing the on-curve
+        // check with an unrelated x-coordinate.
+        let mut rng = rand::thread_rng();
+        let mut g2 = G2::random(&mut rng);
+        g2.normalize();
+        let g2: SAffineG2 = AffineG2::new(g2.x(), g2.y()).unwrap().into();
+
+        let mut bytes = g2.to_gnark_compressed_bytes();
+        bytes[0] = (bytes[0] & !MASK) | COMPRESSED_INFINITY;
 
         let result = SAffineG2::from_gnark_compressed_bytes(&bytes);
 


### PR DESCRIPTION
## Description

`SAffineG2::from_gnark_compressed_bytes` handled the gnark `COMPRESSED_INFINITY` flag by returning `AffineG2::from_jacobian(G2::one())` — but in substrate-bn `G2::one()` is the **generator**, not the point at infinity. An infinity-flagged encoding was therefore silently decoded to a completely different (valid) point instead of being rejected.

This isn't a soundness hole — an attacker wanting the generator can just encode the generator — but silently substituting a point is wrong and inconsistent with G1, which already rejects this flag. The point at infinity has no affine representation and never appears in a valid Groth16 proof or verifying key, so rejecting it is correct. Found while auditing point-validation paths around the `Groth16Proof` serde fix (`codex/propose-fix-for-groth16proof-vulnerability`).

G2's decoder ends with the same catch-all flag match G1 uses (`_ => Err(InvalidDataFormatError)`), so once the buggy early return is removed, no G2-specific special case is needed at all — any flag other than positive/negative already falls into that arm. This also surfaced a couple of doc comments that mis-described `MASK`/`COMPRESSED_POSITIVE`/`COMPRESSED_NEGATIVE`/`COMPRESSED_INFINITY` as applying to only one of G1/G2, when both curves share the same flag byte encoding.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [x] New or updated tests

## Notes to Reviewers

The serializers (`to_gnark_compressed_bytes`) never emit the infinity flag, so round-trips are unaffected — only hand-crafted or foreign encodings could carry it. The regression test builds a genuine on-curve G2 point and overwrites its flag byte with `COMPRESSED_INFINITY`, so it exercises flag rejection specifically rather than incidentally failing the on-curve check with an unrelated x-coordinate.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
