### PR TITLE
feat(perf-report): diff perf results against the last merged PR's report

### DIFF
--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -2,6 +2,10 @@ name: Run prover guest code checks
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -2,10 +2,6 @@ name: Run prover guest code checks
 
 on: pull_request
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 permissions: {}
 
 jobs:

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -3,7 +3,7 @@ name: Run prover guest code checks
 on: pull_request
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions: {}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6168,6 +6168,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/perf-report/Cargo.toml
+++ b/perf-report/Cargo.toml
@@ -12,6 +12,6 @@ zkaleido.workspace = true
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
 num-format = "0.4.4"
-reqwest = { version = "0.13.3", features = ["json"] }
+reqwest = { version = "0.13.3", features = ["json", "query"] }
 serde.workspace = true
 serde_json = "1.0.150"

--- a/perf-report/src/args.rs
+++ b/perf-report/src/args.rs
@@ -3,7 +3,10 @@ use std::{env, fmt};
 use anyhow::{Context, Result};
 use clap::Args;
 
-use crate::github::{DEFAULT_API_BASE_URL, GithubPrReporter, GithubPrReporterConfig};
+use crate::github::{
+    DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK, GithubPrReporter,
+    GithubPrReporterConfig,
+};
 
 /// Returns the PR number parsed from the `GITHUB_REF` env var set by GitHub
 /// Actions (`refs/pull/<number>/merge` on pull_request-triggered runs),
@@ -91,6 +94,15 @@ pub struct GithubReportArgs {
     /// Defaults to the base branch of the PR that triggered the CI run.
     #[arg(long, default_value_t = default_base_branch())]
     pub base_branch: String,
+
+    /// How many base branch commits to walk back when looking for the
+    /// baseline report. Zero disables the lookup.
+    ///
+    /// The window counts commits, not PRs: with squash merges the two
+    /// coincide, but with rebase or merge-commit merges a single PR can
+    /// span many commits, so a larger window may be needed.
+    #[arg(long, default_value_t = DEFAULT_BASELINE_COMMIT_LOOKBACK)]
+    pub baseline_commit_lookback: usize,
 }
 
 impl GithubReportArgs {
@@ -116,6 +128,7 @@ impl GithubReportArgs {
             // An empty branch (e.g. outside CI) means unset, which
             // disables baseline lookup.
             base_branch: Some(self.base_branch.clone()).filter(|branch| !branch.trim().is_empty()),
+            baseline_commit_lookback: self.baseline_commit_lookback,
             ..Default::default()
         })
     }
@@ -130,6 +143,7 @@ impl fmt::Debug for GithubReportArgs {
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
             .field("base_branch", &self.base_branch)
+            .field("baseline_commit_lookback", &self.baseline_commit_lookback)
             .finish()
     }
 }

--- a/perf-report/src/args.rs
+++ b/perf-report/src/args.rs
@@ -31,6 +31,13 @@ fn default_commit_hash() -> String {
     env::var("GITHUB_SHA").unwrap_or_default()
 }
 
+/// Returns the base branch from the `GITHUB_BASE_REF` env var set by GitHub
+/// Actions (the PR's target branch on pull_request-triggered runs), empty
+/// on any other trigger or outside of CI.
+fn default_base_branch() -> String {
+    env::var("GITHUB_BASE_REF").unwrap_or_default()
+}
+
 /// Returns the API base URL from the `GITHUB_API_URL` env var set by GitHub
 /// Actions (which points at the enterprise host on GHES), falling back to
 /// the public GitHub API outside of CI.
@@ -77,6 +84,13 @@ pub struct GithubReportArgs {
     /// Defaults to the commit that triggered the CI run.
     #[arg(long, default_value_t = default_commit_hash())]
     pub commit_hash: String,
+
+    /// Base branch whose most recently merged PR provides the baseline
+    /// report to diff against.
+    ///
+    /// Defaults to the base branch of the PR that triggered the CI run.
+    #[arg(long, default_value_t = default_base_branch())]
+    pub base_branch: String,
 }
 
 impl GithubReportArgs {
@@ -99,6 +113,9 @@ impl GithubReportArgs {
             // An empty hash (e.g. outside CI) means unset, so the header
             // falls back to "Local execution".
             commit_hash: Some(self.commit_hash.clone()).filter(|hash| !hash.trim().is_empty()),
+            // An empty branch (e.g. outside CI) means unset, which
+            // disables baseline lookup.
+            base_branch: Some(self.base_branch.clone()).filter(|branch| !branch.trim().is_empty()),
             ..Default::default()
         })
     }
@@ -112,6 +129,7 @@ impl fmt::Debug for GithubReportArgs {
             .field("github_repo", &self.github_repo)
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
+            .field("base_branch", &self.base_branch)
             .finish()
     }
 }

--- a/perf-report/src/args.rs
+++ b/perf-report/src/args.rs
@@ -34,13 +34,6 @@ fn default_commit_hash() -> String {
     env::var("GITHUB_SHA").unwrap_or_default()
 }
 
-/// Returns the base branch from the `GITHUB_BASE_REF` env var set by GitHub
-/// Actions (the PR's target branch on pull_request-triggered runs), empty
-/// on any other trigger or outside of CI.
-fn default_base_branch() -> String {
-    env::var("GITHUB_BASE_REF").unwrap_or_default()
-}
-
 /// Returns the API base URL from the `GITHUB_API_URL` env var set by GitHub
 /// Actions (which points at the enterprise host on GHES), falling back to
 /// the public GitHub API outside of CI.
@@ -88,13 +81,6 @@ pub struct GithubReportArgs {
     #[arg(long, default_value_t = default_commit_hash())]
     pub commit_hash: String,
 
-    /// Base branch whose most recently merged PR provides the baseline
-    /// report to diff against.
-    ///
-    /// Defaults to the base branch of the PR that triggered the CI run.
-    #[arg(long, default_value_t = default_base_branch())]
-    pub base_branch: String,
-
     /// How many base branch commits to walk back when looking for the
     /// baseline report. Zero disables the lookup.
     ///
@@ -125,9 +111,6 @@ impl GithubReportArgs {
             // An empty hash (e.g. outside CI) means unset, so the header
             // falls back to "Local execution".
             commit_hash: Some(self.commit_hash.clone()).filter(|hash| !hash.trim().is_empty()),
-            // An empty branch (e.g. outside CI) means unset, which
-            // disables baseline lookup.
-            base_branch: Some(self.base_branch.clone()).filter(|branch| !branch.trim().is_empty()),
             baseline_commit_lookback: self.baseline_commit_lookback,
             ..Default::default()
         })
@@ -142,7 +125,6 @@ impl fmt::Debug for GithubReportArgs {
             .field("github_repo", &self.github_repo)
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
-            .field("base_branch", &self.base_branch)
             .field("baseline_commit_lookback", &self.baseline_commit_lookback)
             .finish()
     }

--- a/perf-report/src/args.rs
+++ b/perf-report/src/args.rs
@@ -5,8 +5,8 @@ use clap::Args;
 use serde_json::Value;
 
 use crate::github::{
-    DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK, GithubPrReporter,
-    GithubPrReporterConfig,
+    DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK, DEFAULT_EXPECTED_COMMENT_AUTHOR,
+    GithubPrReporter, GithubPrReporterConfig,
 };
 
 /// Returns the PR number parsed from the `GITHUB_REF` env var set by GitHub
@@ -145,6 +145,18 @@ pub struct GithubReportArgs {
     /// lookup runs.
     #[arg(long, default_value_t = default_base_sha())]
     pub base_sha: String,
+
+    /// Expected GitHub login of the sticky report comment's author.
+    ///
+    /// A comment is only ever treated as a genuine report -- to patch when
+    /// posting, or to read back as a baseline -- when it was posted by
+    /// this identity; otherwise anyone who can comment on a PR could forge
+    /// a fake report. Defaults to the identity GitHub attributes comments
+    /// to when posted with the default `GITHUB_TOKEN`; override this if
+    /// posting with a different token (a custom bot account, a GitHub App
+    /// installation, or a PAT).
+    #[arg(long, default_value = DEFAULT_EXPECTED_COMMENT_AUTHOR)]
+    pub expected_comment_author: String,
 }
 
 impl GithubReportArgs {
@@ -172,6 +184,7 @@ impl GithubReportArgs {
             // unset, so the baseline anchor falls back to a live lookup.
             base_ref: Some(self.base_ref.clone()).filter(|s| !s.trim().is_empty()),
             base_sha: Some(self.base_sha.clone()).filter(|s| !s.trim().is_empty()),
+            expected_comment_author: self.expected_comment_author.clone(),
             ..Default::default()
         })
     }
@@ -188,6 +201,7 @@ impl fmt::Debug for GithubReportArgs {
             .field("baseline_commit_lookback", &self.baseline_commit_lookback)
             .field("base_ref", &self.base_ref)
             .field("base_sha", &self.base_sha)
+            .field("expected_comment_author", &self.expected_comment_author)
             .finish()
     }
 }

--- a/perf-report/src/args.rs
+++ b/perf-report/src/args.rs
@@ -45,17 +45,18 @@ fn default_api_base_url() -> String {
         .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string())
 }
 
-/// Returns `pull_request.base.<field>` from the webhook payload at
+/// Returns `pull_request.<path>` from the webhook payload at
 /// `GITHUB_EVENT_PATH` (set by GitHub Actions for every trigger), empty if
 /// the env var is unset, the file can't be read, or the trigger wasn't
 /// `pull_request`.
 ///
-/// This is the base commit/branch GitHub actually resolved when the event
-/// fired, fixed for the lifetime of the run. A live API lookup of the PR's
-/// base is a poor substitute: the base branch can advance between the event
-/// firing and the lookup running, silently anchoring to a commit newer than
-/// what `GITHUB_SHA` was actually built from.
-fn default_pull_request_base_field(field: &str) -> String {
+/// This reflects what GitHub actually resolved when the event fired, fixed
+/// for the lifetime of the run. A live API lookup is a poor substitute for
+/// values that can change over time (the base branch can advance, the PR
+/// head can get new commits): resolving live would silently pick up
+/// whatever the PR looks like when the lookup happens to run, not what
+/// `GITHUB_SHA` was actually built from.
+fn default_pull_request_field(path: &[&str]) -> String {
     let Ok(event_path) = env::var("GITHUB_EVENT_PATH") else {
         return String::new();
     };
@@ -65,22 +66,29 @@ fn default_pull_request_base_field(field: &str) -> String {
     let Ok(event) = serde_json::from_str::<Value>(&contents) else {
         return String::new();
     };
-    event["pull_request"]["base"][field]
-        .as_str()
-        .map(str::to_string)
-        .unwrap_or_default()
+    let mut value = &event["pull_request"];
+    for segment in path {
+        value = &value[*segment];
+    }
+    value.as_str().map(str::to_string).unwrap_or_default()
 }
 
 /// Returns the base branch ref name from the triggering event. See
-/// [`default_pull_request_base_field`].
+/// [`default_pull_request_field`].
 fn default_base_ref() -> String {
-    default_pull_request_base_field("ref")
+    default_pull_request_field(&["base", "ref"])
 }
 
 /// Returns the base branch commit SHA from the triggering event. See
-/// [`default_pull_request_base_field`].
+/// [`default_pull_request_field`].
 fn default_base_sha() -> String {
-    default_pull_request_base_field("sha")
+    default_pull_request_field(&["base", "sha"])
+}
+
+/// Returns the PR head commit SHA from the triggering event. See
+/// [`default_pull_request_field`].
+fn default_head_sha() -> String {
+    default_pull_request_field(&["head", "sha"])
 }
 
 /// CLI arguments for posting a performance report to a GitHub PR.
@@ -157,6 +165,18 @@ pub struct GithubReportArgs {
     /// installation, or a PAT).
     #[arg(long, default_value = DEFAULT_EXPECTED_COMMENT_AUTHOR)]
     pub expected_comment_author: String,
+
+    /// PR head commit SHA this run is testing.
+    ///
+    /// Defaults to the head SHA of the triggering pull_request event.
+    /// Before posting, this is checked against the PR's current head; a
+    /// mismatch means a newer push has already been tested (concurrency
+    /// cancellation only catches *overlapping* runs, not a re-run of an
+    /// older completed one), so the report is skipped instead of
+    /// overwriting a fresher one. Empty (e.g. outside CI) disables the
+    /// check.
+    #[arg(long, default_value_t = default_head_sha())]
+    pub head_sha: String,
 }
 
 impl GithubReportArgs {
@@ -185,6 +205,7 @@ impl GithubReportArgs {
             base_ref: Some(self.base_ref.clone()).filter(|s| !s.trim().is_empty()),
             base_sha: Some(self.base_sha.clone()).filter(|s| !s.trim().is_empty()),
             expected_comment_author: self.expected_comment_author.clone(),
+            head_sha: Some(self.head_sha.clone()).filter(|s| !s.trim().is_empty()),
             ..Default::default()
         })
     }
@@ -202,6 +223,7 @@ impl fmt::Debug for GithubReportArgs {
             .field("base_ref", &self.base_ref)
             .field("base_sha", &self.base_sha)
             .field("expected_comment_author", &self.expected_comment_author)
+            .field("head_sha", &self.head_sha)
             .finish()
     }
 }

--- a/perf-report/src/args.rs
+++ b/perf-report/src/args.rs
@@ -1,7 +1,8 @@
-use std::{env, fmt};
+use std::{env, fmt, fs};
 
 use anyhow::{Context, Result};
 use clap::Args;
+use serde_json::Value;
 
 use crate::github::{
     DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK, GithubPrReporter,
@@ -42,6 +43,44 @@ fn default_api_base_url() -> String {
         .ok()
         .filter(|url| !url.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_API_BASE_URL.to_string())
+}
+
+/// Returns `pull_request.base.<field>` from the webhook payload at
+/// `GITHUB_EVENT_PATH` (set by GitHub Actions for every trigger), empty if
+/// the env var is unset, the file can't be read, or the trigger wasn't
+/// `pull_request`.
+///
+/// This is the base commit/branch GitHub actually resolved when the event
+/// fired, fixed for the lifetime of the run. A live API lookup of the PR's
+/// base is a poor substitute: the base branch can advance between the event
+/// firing and the lookup running, silently anchoring to a commit newer than
+/// what `GITHUB_SHA` was actually built from.
+fn default_pull_request_base_field(field: &str) -> String {
+    let Ok(event_path) = env::var("GITHUB_EVENT_PATH") else {
+        return String::new();
+    };
+    let Ok(contents) = fs::read_to_string(event_path) else {
+        return String::new();
+    };
+    let Ok(event) = serde_json::from_str::<Value>(&contents) else {
+        return String::new();
+    };
+    event["pull_request"]["base"][field]
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
+/// Returns the base branch ref name from the triggering event. See
+/// [`default_pull_request_base_field`].
+fn default_base_ref() -> String {
+    default_pull_request_base_field("ref")
+}
+
+/// Returns the base branch commit SHA from the triggering event. See
+/// [`default_pull_request_base_field`].
+fn default_base_sha() -> String {
+    default_pull_request_base_field("sha")
 }
 
 /// CLI arguments for posting a performance report to a GitHub PR.
@@ -89,6 +128,23 @@ pub struct GithubReportArgs {
     /// span many commits, so a larger window may be needed.
     #[arg(long, default_value_t = DEFAULT_BASELINE_COMMIT_LOOKBACK)]
     pub baseline_commit_lookback: usize,
+
+    /// Base branch ref name to anchor the baseline commit walk to.
+    ///
+    /// Defaults to the base ref of the triggering pull_request event.
+    /// Falls back to a live lookup of the PR's current base outside of CI.
+    #[arg(long, default_value_t = default_base_ref())]
+    pub base_ref: String,
+
+    /// Base branch commit SHA to anchor the baseline commit walk to.
+    ///
+    /// Defaults to the base SHA of the triggering pull_request event: the
+    /// commit GitHub actually resolved the PR's base to when the event
+    /// fired. Falls back to a live lookup of the PR's current base tip
+    /// outside of CI, which is racy if the base branch advances before the
+    /// lookup runs.
+    #[arg(long, default_value_t = default_base_sha())]
+    pub base_sha: String,
 }
 
 impl GithubReportArgs {
@@ -112,6 +168,10 @@ impl GithubReportArgs {
             // falls back to "Local execution".
             commit_hash: Some(self.commit_hash.clone()).filter(|hash| !hash.trim().is_empty()),
             baseline_commit_lookback: self.baseline_commit_lookback,
+            // Empty (e.g. outside CI or a non-pull_request trigger) means
+            // unset, so the baseline anchor falls back to a live lookup.
+            base_ref: Some(self.base_ref.clone()).filter(|s| !s.trim().is_empty()),
+            base_sha: Some(self.base_sha.clone()).filter(|s| !s.trim().is_empty()),
             ..Default::default()
         })
     }
@@ -126,6 +186,8 @@ impl fmt::Debug for GithubReportArgs {
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
             .field("baseline_commit_lookback", &self.baseline_commit_lookback)
+            .field("base_ref", &self.base_ref)
+            .field("base_sha", &self.base_sha)
             .finish()
     }
 }

--- a/perf-report/src/diff.rs
+++ b/perf-report/src/diff.rs
@@ -1,0 +1,44 @@
+use num_format::{Locale, ToFormattedString};
+
+/// Formats the change from `baseline` to `current` as e.g. `+1,234 (+5.6%)`.
+///
+/// The percentage is omitted when `baseline` is zero, and a zero change
+/// renders as `0 (0.0%)`.
+pub(crate) fn format_delta(current: u64, baseline: u64) -> String {
+    let delta = i128::from(current) - i128::from(baseline);
+    if delta == 0 {
+        return "0 (0.0%)".to_string();
+    }
+    let sign = if delta < 0 { "-" } else { "+" };
+    let magnitude = delta.unsigned_abs().to_formatted_string(&Locale::en);
+    if baseline == 0 {
+        return format!("{sign}{magnitude}");
+    }
+    let percent = delta as f64 / baseline as f64 * 100.0;
+    format!("{sign}{magnitude} ({percent:+.1}%)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_increase() {
+        assert_eq!(format_delta(1_100, 1_000), "+100 (+10.0%)");
+    }
+
+    #[test]
+    fn formats_decrease() {
+        assert_eq!(format_delta(900_000, 1_000_000), "-100,000 (-10.0%)");
+    }
+
+    #[test]
+    fn formats_no_change() {
+        assert_eq!(format_delta(1_000, 1_000), "0 (0.0%)");
+    }
+
+    #[test]
+    fn omits_percent_for_zero_baseline() {
+        assert_eq!(format_delta(500, 0), "+500");
+    }
+}

--- a/perf-report/src/format.rs
+++ b/perf-report/src/format.rs
@@ -1,18 +1,37 @@
 use num_format::{Locale, ToFormattedString};
 
-use crate::report::ZkVmResults;
+use crate::{
+    diff::format_delta,
+    payload::{ProgramPayload, ReportPayload, ZkVmPayload},
+    report::ZkVmResults,
+};
 
-/// Renders the full performance report: one results table per zkVM.
-pub fn render_report(results: &[ZkVmResults]) -> String {
+/// Renders the full performance report: one results table per zkVM, with
+/// per-program delta columns against `baseline` when one is given.
+pub fn render_report(results: &[ZkVmResults], baseline: Option<&ReportPayload>) -> String {
     results
         .iter()
-        .map(format_results)
+        .map(|zkvm_results| {
+            let zkvm_baseline =
+                baseline.and_then(|payload| payload.zkvm(&zkvm_results.zkvm.to_string()));
+            format_results(zkvm_results, zkvm_baseline)
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-/// Returns formatted results for one zkVM as a table.
-pub fn format_results(results: &ZkVmResults) -> String {
+/// Returns formatted results for one zkVM as a table, with delta columns
+/// against `baseline` when one is given.
+pub fn format_results(results: &ZkVmResults, baseline: Option<&ZkVmPayload>) -> String {
+    let table_text = match baseline {
+        Some(baseline) => format_table_with_deltas(results, baseline),
+        None => format_table(results),
+    };
+    format!("**{} Execution Results**\n {table_text}", results.zkvm)
+}
+
+/// Builds the results table without a baseline to compare against.
+fn format_table(results: &ZkVmResults) -> String {
     let mut table_text = String::new();
     table_text.push('\n');
     table_text.push_str("| program                | cycles      | gas         |\n");
@@ -23,14 +42,143 @@ pub fn format_results(results: &ZkVmResults) -> String {
             "\n| {:<22} | {:>11} | {:>11} |",
             program.name,
             program.summary.cycles().to_formatted_string(&Locale::en),
-            program
-                .summary
-                .gas()
-                .map(|g| g.to_formatted_string(&Locale::en))
-                .unwrap_or_else(|| "-".to_string()),
+            format_gas(program.summary.gas()),
         ));
     }
     table_text.push('\n');
+    table_text
+}
 
-    format!("**{} Execution Results**\n {table_text}", results.zkvm)
+/// Builds the results table with delta columns against `baseline`.
+fn format_table_with_deltas(results: &ZkVmResults, baseline: &ZkVmPayload) -> String {
+    let mut table_text = String::new();
+    table_text.push('\n');
+    table_text.push_str(&format!(
+        "| {:<22} | {:<11} | {:<11} | {:<20} | {:<20} |\n",
+        "program", "cycles", "gas", "Δ cycles", "Δ gas"
+    ));
+    table_text.push_str(&format!(
+        "|{:-<24}|{:-<13}|{:-<13}|{:-<22}|{:-<22}|",
+        "", "", "", "", ""
+    ));
+
+    for program in &results.results {
+        let baseline_program = baseline.program(&program.name);
+        let cycles = program.summary.cycles();
+        let gas = program.summary.gas();
+        table_text.push_str(&format!(
+            "\n| {:<22} | {:>11} | {:>11} | {:>20} | {:>20} |",
+            program.name,
+            cycles.to_formatted_string(&Locale::en),
+            format_gas(gas),
+            format_cycles_delta(cycles, baseline_program),
+            format_gas_delta(gas, baseline_program),
+        ));
+    }
+    table_text.push('\n');
+    table_text
+}
+
+/// Formats an optional gas amount, `-` when the program reports none.
+fn format_gas(gas: Option<u64>) -> String {
+    gas.map(|gas| gas.to_formatted_string(&Locale::en))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Formats the cycles delta column: `new` for programs the baseline does
+/// not cover.
+fn format_cycles_delta(cycles: u64, baseline: Option<&ProgramPayload>) -> String {
+    match baseline {
+        Some(baseline) => format_delta(cycles, baseline.cycles),
+        None => "new".to_string(),
+    }
+}
+
+/// Formats the gas delta column: `-` when the program reports no gas,
+/// `new` when only the baseline is missing it.
+fn format_gas_delta(gas: Option<u64>, baseline: Option<&ProgramPayload>) -> String {
+    match (gas, baseline.and_then(|baseline| baseline.gas)) {
+        (Some(gas), Some(baseline_gas)) => format_delta(gas, baseline_gas),
+        (Some(_), None) => "new".to_string(),
+        (None, _) => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zkaleido::{ExecutionSummary, PublicValues, ZkVm};
+
+    use super::*;
+
+    fn sample_results() -> ZkVmResults {
+        ZkVmResults::new(
+            ZkVm::SP1,
+            vec![
+                (
+                    "fibonacci".to_string(),
+                    ExecutionSummary::new(PublicValues::default(), 1_100, Some(220)),
+                ),
+                (
+                    "sha2-chain".to_string(),
+                    ExecutionSummary::new(PublicValues::default(), 900_000, None),
+                ),
+                (
+                    "new-program".to_string(),
+                    ExecutionSummary::new(PublicValues::default(), 42, Some(7)),
+                ),
+            ],
+        )
+    }
+
+    fn sample_baseline() -> ReportPayload {
+        ReportPayload {
+            zkvms: vec![ZkVmPayload {
+                zkvm: "SP1".to_string(),
+                results: vec![
+                    ProgramPayload {
+                        name: "fibonacci".to_string(),
+                        cycles: 1_000,
+                        gas: Some(200),
+                    },
+                    ProgramPayload {
+                        name: "sha2-chain".to_string(),
+                        cycles: 1_000_000,
+                        gas: None,
+                    },
+                ],
+            }],
+        }
+    }
+
+    #[test]
+    fn renders_without_baseline() {
+        let report = render_report(&[sample_results()], None);
+        assert!(report.contains("**SP1 Execution Results**"));
+        assert!(report.contains("| program                | cycles      | gas         |"));
+        assert!(!report.contains("Δ cycles"));
+    }
+
+    #[test]
+    fn renders_deltas_against_baseline() {
+        let baseline = sample_baseline();
+        let report = render_report(&[sample_results()], Some(&baseline));
+
+        assert!(report.contains("Δ cycles"));
+        assert!(report.contains("Δ gas"));
+        // fibonacci: both cycles and gas went up 10% over the baseline.
+        assert!(report.contains("+100 (+10.0%)"));
+        assert!(report.contains("+20 (+10.0%)"));
+        // sha2-chain: cycles went down, gas is not reported at all.
+        assert!(report.contains("-100,000 (-10.0%)"));
+        // new-program: absent from the baseline.
+        assert!(report.contains("new"));
+    }
+
+    #[test]
+    fn ignores_baseline_of_other_zkvm() {
+        let mut baseline = sample_baseline();
+        baseline.zkvms[0].zkvm = "Risc0".to_string();
+        let report = render_report(&[sample_results()], Some(&baseline));
+        assert!(!report.contains("Δ cycles"));
+    }
 }

--- a/perf-report/src/format.rs
+++ b/perf-report/src/format.rs
@@ -133,6 +133,7 @@ mod tests {
     fn sample_baseline() -> ReportPayload {
         ReportPayload {
             base_sha: Some("abc123".to_string()),
+            head_sha: Some("head123".to_string()),
             zkvms: vec![ZkVmPayload {
                 zkvm: "SP1".to_string(),
                 results: vec![

--- a/perf-report/src/format.rs
+++ b/perf-report/src/format.rs
@@ -132,6 +132,7 @@ mod tests {
 
     fn sample_baseline() -> ReportPayload {
         ReportPayload {
+            base_sha: Some("abc123".to_string()),
             zkvms: vec![ZkVmPayload {
                 zkvm: "SP1".to_string(),
                 results: vec![

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use anyhow::{Result, anyhow, bail};
 use reqwest::{Client, RequestBuilder};
@@ -65,33 +65,40 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
         .and_then(|pull| pull["number"].as_u64())
 }
 
-/// Returns whether `payload` was tested against exactly the base state
-/// `commit` (the candidate's merge commit) landed on, i.e. `payload.base_sha`
-/// matches `commit`'s first parent.
+/// Returns whether `payload` was tested against exactly the base state the
+/// candidate's commit span landed on.
+///
+/// Starting at `merge_sha` (the candidate's merge commit), walks back
+/// through first-parent links looking for `payload.base_sha`: one hop for
+/// a squash commit or a standard two-parent merge commit, one hop per
+/// rebased commit for rebase-and-merge, since GitHub replays each of the
+/// PR's commits individually onto the base tip and every one of them
+/// lands in the base branch's own history. `parent_of` should map each
+/// base-branch commit's sha to its first parent's sha, built from the
+/// already-fetched commit history.
 ///
 /// If the base branch advanced after the candidate PR's last CI run but
-/// before it merged, `payload.base_sha` names a commit that is no longer
-/// the merge's parent; using such a payload as a baseline would silently
-/// attribute the base branch's intervening changes to whichever PR is
-/// compared against it next. A payload with no `base_sha` (e.g. posted
-/// before this field existed) can't be verified and is treated as stale.
-///
-/// This assumes the merge landed as a squash or a standard two-parent
-/// merge commit, where `parents[0]` is the base tip immediately before the
-/// merge.
-///
-/// TODO: rebase-and-merge instead replays the PR's commits individually,
-/// so `parents[0]` of the last one is another of the PR's own commits, not
-/// the pre-merge base; this check would then reject even a fresh candidate
-/// on repositories using that merge strategy.
-fn baseline_is_fresh(commit: &Value, payload: &ReportPayload) -> bool {
+/// before it merged, `payload.base_sha` won't appear anywhere in this
+/// walk; using such a payload as a baseline would silently attribute the
+/// base branch's intervening changes to whichever PR is compared against
+/// it next. A payload with no `base_sha` (e.g. posted before this field
+/// existed) can't be verified and is treated as stale.
+fn baseline_is_fresh(
+    merge_sha: &str,
+    parent_of: &HashMap<&str, &str>,
+    payload: &ReportPayload,
+) -> bool {
     let Some(tested_base_sha) = payload.base_sha.as_deref() else {
         return false;
     };
-    let Some(base_parent_sha) = commit["parents"][0]["sha"].as_str() else {
-        return false;
-    };
-    tested_base_sha == base_parent_sha
+    let mut sha = merge_sha;
+    while let Some(&parent_sha) = parent_of.get(sha) {
+        if parent_sha == tested_base_sha {
+            return true;
+        }
+        sha = parent_sha;
+    }
+    false
 }
 
 /// Returns the first 8 characters of a commit hash.
@@ -348,6 +355,15 @@ impl GithubPrReporter {
             )
             .await?;
 
+        let parent_of: HashMap<&str, &str> = commits
+            .iter()
+            .filter_map(|commit| {
+                let sha = commit["sha"].as_str()?;
+                let parent_sha = commit["parents"][0]["sha"].as_str()?;
+                Some((sha, parent_sha))
+            })
+            .collect();
+
         for commit in &commits {
             let Some(sha) = commit["sha"].as_str() else {
                 continue;
@@ -362,7 +378,7 @@ impl GithubPrReporter {
             else {
                 continue;
             };
-            if !baseline_is_fresh(commit, &payload) {
+            if !baseline_is_fresh(sha, &parent_of, &payload) {
                 continue;
             }
             return Ok(Some(BaselineReport {
@@ -597,31 +613,45 @@ mod tests {
 
     #[test]
     fn baseline_is_fresh_when_tested_base_matches_merge_parent() {
-        let commit = json!({"sha": "merge1", "parents": [{"sha": "base1"}]});
+        let parent_of = HashMap::from([("merge1", "base1")]);
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(baseline_is_fresh(&commit, &payload));
+        assert!(baseline_is_fresh("merge1", &parent_of, &payload));
+    }
+
+    #[test]
+    fn baseline_is_fresh_across_a_multi_commit_rebase_span() {
+        // Rebase-and-merge replays each of the PR's commits individually;
+        // the tested base is several hops back through the PR's own
+        // commits, not the merge commit's direct parent.
+        let parent_of = HashMap::from([
+            ("rebased3", "rebased2"),
+            ("rebased2", "rebased1"),
+            ("rebased1", "base1"),
+        ]);
+        let payload = payload_with_base_sha(Some("base1"));
+        assert!(baseline_is_fresh("rebased3", &parent_of, &payload));
     }
 
     #[test]
     fn baseline_is_stale_when_base_advanced_before_merge() {
         // The candidate was last tested against `base1`, but by the time it
         // merged the base branch had moved on to `base2`.
-        let commit = json!({"sha": "merge1", "parents": [{"sha": "base2"}]});
+        let parent_of = HashMap::from([("merge1", "base2")]);
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(!baseline_is_fresh(&commit, &payload));
+        assert!(!baseline_is_fresh("merge1", &parent_of, &payload));
     }
 
     #[test]
     fn baseline_is_stale_without_a_tested_base_sha() {
-        let commit = json!({"sha": "merge1", "parents": [{"sha": "base1"}]});
+        let parent_of = HashMap::from([("merge1", "base1")]);
         let payload = payload_with_base_sha(None);
-        assert!(!baseline_is_fresh(&commit, &payload));
+        assert!(!baseline_is_fresh("merge1", &parent_of, &payload));
     }
 
     #[test]
     fn baseline_is_stale_without_commit_parents() {
-        let commit = json!({"sha": "merge1", "parents": []});
+        let parent_of = HashMap::new();
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(!baseline_is_fresh(&commit, &payload));
+        assert!(!baseline_is_fresh("merge1", &parent_of, &payload));
     }
 }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -43,14 +43,12 @@ fn find_sticky_comment<'a>(comments: &'a [Value], hidden_marker: &str) -> Option
     })
 }
 
-/// Returns the number of the first of `pulls` that was merged into
-/// `base_branch`.
-fn first_merged_pr(pulls: &[Value], base_branch: &str) -> Option<u64> {
-    pulls
+/// Returns the number of the merged pull request in `merged_pulls` whose
+/// merge commit is `sha`.
+fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
+    merged_pulls
         .iter()
-        .find(|pull| {
-            !pull["merged_at"].is_null() && pull["base"]["ref"].as_str() == Some(base_branch)
-        })
+        .find(|pull| !pull["merged_at"].is_null() && pull["merge_commit_sha"].as_str() == Some(sha))
         .and_then(|pull| pull["number"].as_u64())
 }
 
@@ -187,13 +185,17 @@ impl GithubPrReporter {
     /// the sticky report comment of the most recently merged PR on the base
     /// branch. The base branch is resolved from the PR being reported on,
     /// so no configuration is needed and any trigger type works. Walks the
-    /// base branch history commit by commit, so commits without a merged PR
-    /// (direct pushes) and PRs without a readable report (failed perf job,
-    /// predates the embedded payload) are skipped in favor of an older
-    /// baseline. Returns `None` when the lookback is zero or nothing is
-    /// found within the lookback window; a missing baseline only degrades
-    /// the report to absolute numbers, so callers can treat errors the same
-    /// way.
+    /// base branch history commit by commit, matching each commit to a
+    /// merged PR by `merge_commit_sha` rather than GitHub's commit-to-PR
+    /// association endpoint, which only reports merged PRs for commits
+    /// reachable from the repository's default branch and would otherwise
+    /// miss every PR merged into a non-default base. Commits without a
+    /// matching merged PR (direct pushes) and PRs without a readable report
+    /// (failed perf job, predates the embedded payload) are skipped in
+    /// favor of an older baseline. Returns `None` when the lookback is zero
+    /// or nothing is found within the lookback window; a missing baseline
+    /// only degrades the report to absolute numbers, so callers can treat
+    /// errors the same way.
     pub async fn fetch_baseline(&self) -> Result<Option<BaselineReport>> {
         // Guard explicitly: the GitHub API treats `per_page=0` as "use the
         // default page size" rather than "no commits".
@@ -204,8 +206,8 @@ impl GithubPrReporter {
         let client = Client::new();
         let base_branch = self.fetch_pr_base_branch(&client).await?;
         // TODO: lookbacks above 100 are silently capped by the GitHub API,
-        // which serves at most one page of commits; paginate to support
-        // larger windows.
+        // which serves at most one page of commits or merged pull requests;
+        // paginate to support larger windows.
         let lookback = self.config.baseline_commit_lookback.to_string();
         let commits_url = format!(
             "{}/repos/{}/commits",
@@ -220,18 +222,30 @@ impl GithubPrReporter {
             )
             .await?;
 
+        let pulls_url = format!(
+            "{}/repos/{}/pulls",
+            self.config.api_base_url, self.config.repo
+        );
+        let merged_pulls = self
+            .get_json_array(
+                &client,
+                &pulls_url,
+                &[
+                    ("base", base_branch.as_str()),
+                    ("state", "closed"),
+                    ("sort", "updated"),
+                    ("direction", "desc"),
+                    ("per_page", &lookback),
+                ],
+                "merged pull requests",
+            )
+            .await?;
+
         for commit in &commits {
             let Some(sha) = commit["sha"].as_str() else {
                 continue;
             };
-            let pulls_url = format!(
-                "{}/repos/{}/commits/{sha}/pulls",
-                self.config.api_base_url, self.config.repo
-            );
-            let pulls = self
-                .get_json_array(&client, &pulls_url, &[], "associated pull requests")
-                .await?;
-            let Some(pr_number) = first_merged_pr(&pulls, &base_branch) else {
+            let Some(pr_number) = find_pr_for_merge_commit(&merged_pulls, sha) else {
                 continue;
             };
             let comments = self.fetch_comments(&client, pr_number).await?;
@@ -415,14 +429,14 @@ mod tests {
     }
 
     #[test]
-    fn picks_merged_pr_targeting_base_branch() {
-        let pulls = vec![
-            json!({"number": 1, "merged_at": null, "base": {"ref": "main"}}),
-            json!({"number": 2, "merged_at": "2026-07-01T00:00:00Z", "base": {"ref": "dev"}}),
-            json!({"number": 3, "merged_at": "2026-07-01T00:00:00Z", "base": {"ref": "main"}}),
+    fn finds_pr_by_merge_commit_sha() {
+        let merged_pulls = vec![
+            json!({"number": 1, "merged_at": null, "merge_commit_sha": "abc123"}),
+            json!({"number": 2, "merged_at": "2026-07-01T00:00:00Z", "merge_commit_sha": "def456"}),
+            json!({"number": 3, "merged_at": "2026-07-01T00:00:00Z", "merge_commit_sha": "abc123"}),
         ];
-        assert_eq!(first_merged_pr(&pulls, "main"), Some(3));
-        assert_eq!(first_merged_pr(&pulls, "dev"), Some(2));
-        assert_eq!(first_merged_pr(&pulls, "release"), None);
+        assert_eq!(find_pr_for_merge_commit(&merged_pulls, "abc123"), Some(3));
+        assert_eq!(find_pr_for_merge_commit(&merged_pulls, "def456"), Some(2));
+        assert_eq!(find_pr_for_merge_commit(&merged_pulls, "missing"), None);
     }
 }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -41,18 +41,31 @@ pub struct BaselineAnchor {
     base_sha: String,
 }
 
-/// Returns the first comment whose body starts with the hidden marker.
+/// Returns the first comment authored by `expected_author` whose body
+/// starts with the hidden marker.
 ///
-/// Only a body that *starts* with the marker counts: the reporter always
-/// writes the marker first, so a comment that merely quotes it (e.g. a
-/// human discussing this report) is never mistaken for the sticky comment
-/// and overwritten.
-fn find_sticky_comment<'a>(comments: &'a [Value], hidden_marker: &str) -> Option<&'a Value> {
+/// Both conditions matter: a body that only *starts* with the marker
+/// means the reporter always writes it first, so a comment that merely
+/// quotes it (e.g. a human discussing this report) is never mistaken for
+/// the sticky comment and overwritten. The author check means a comment
+/// is never trusted purely because of what it says -- on a public repo,
+/// anyone who can comment on a PR can post one starting with the marker
+/// and an arbitrary embedded payload before the real CI job runs; without
+/// checking who posted it, such a forged comment would be indistinguishable
+/// from a genuine report, and if that PR later merges, a future
+/// [`GithubPrReporter::fetch_baseline`] walk would trust the fabricated
+/// numbers as its baseline.
+fn find_sticky_comment<'a>(
+    comments: &'a [Value],
+    hidden_marker: &str,
+    expected_author: &str,
+) -> Option<&'a Value> {
     comments.iter().find(|comment| {
-        comment["body"]
+        let body_matches = comment["body"]
             .as_str()
-            .map(|body| body.starts_with(hidden_marker))
-            .unwrap_or(false)
+            .is_some_and(|body| body.starts_with(hidden_marker));
+        let author_matches = comment["user"]["login"].as_str() == Some(expected_author);
+        body_matches && author_matches
     })
 }
 
@@ -197,6 +210,12 @@ pub const DEFAULT_USER_AGENT: &str = "zkaleido-perf-report";
 /// Default base URL of the GitHub REST API.
 pub const DEFAULT_API_BASE_URL: &str = "https://api.github.com";
 
+/// Default expected author of the sticky report comment: the identity
+/// GitHub attributes comments to when posted with the default
+/// `GITHUB_TOKEN`. Override this if posting with a different token (a
+/// custom bot account, a GitHub App installation, or a PAT).
+pub const DEFAULT_EXPECTED_COMMENT_AUTHOR: &str = "github-actions[bot]";
+
 /// Configuration for a [`GithubPrReporter`], taken in full by
 /// [`GithubPrReporter::new`].
 ///
@@ -233,6 +252,13 @@ pub struct GithubPrReporterConfig {
     /// Base branch commit SHA to anchor the baseline commit walk to. See
     /// [`Self::base_ref`].
     pub base_sha: Option<String>,
+    /// Expected GitHub login of the sticky report comment's author. A
+    /// comment is only ever treated as a genuine report -- to patch when
+    /// posting, or to read back as a baseline -- when it was posted by
+    /// this identity; otherwise anyone who can comment on a PR could
+    /// forge a fake report by posting a comment starting with the hidden
+    /// marker. See [`DEFAULT_EXPECTED_COMMENT_AUTHOR`].
+    pub expected_comment_author: String,
 }
 
 impl Default for GithubPrReporterConfig {
@@ -248,6 +274,7 @@ impl Default for GithubPrReporterConfig {
             baseline_commit_lookback: DEFAULT_BASELINE_COMMIT_LOOKBACK,
             base_ref: None,
             base_sha: None,
+            expected_comment_author: DEFAULT_EXPECTED_COMMENT_AUTHOR.to_string(),
         }
     }
 }
@@ -265,6 +292,7 @@ impl fmt::Debug for GithubPrReporterConfig {
             .field("baseline_commit_lookback", &self.baseline_commit_lookback)
             .field("base_ref", &self.base_ref)
             .field("base_sha", &self.base_sha)
+            .field("expected_comment_author", &self.expected_comment_author)
             .finish()
     }
 }
@@ -431,10 +459,13 @@ impl GithubPrReporter {
                 continue;
             };
             let comments = self.fetch_comments(&client, pr_number).await?;
-            let Some(payload) = find_sticky_comment(&comments, &self.hidden_marker())
-                .and_then(|comment| comment["body"].as_str())
-                .and_then(ReportPayload::extract)
-            else {
+            let Some(payload) = find_sticky_comment(
+                &comments,
+                &self.hidden_marker(),
+                &self.config.expected_comment_author,
+            )
+            .and_then(|comment| comment["body"].as_str())
+            .and_then(ReportPayload::extract) else {
                 continue;
             };
             // Skip the extra work below when there's nothing to validate
@@ -518,7 +549,11 @@ impl GithubPrReporter {
         // CI, where the job-level timeout covers it.
         let client = Client::new();
         let comments = self.fetch_comments(&client, self.config.pr_number).await?;
-        let sticky_comment = find_sticky_comment(&comments, &hidden_marker);
+        let sticky_comment = find_sticky_comment(
+            &comments,
+            &hidden_marker,
+            &self.config.expected_comment_author,
+        );
 
         let request = if let Some(existing_comment) = sticky_comment {
             let comment_url = existing_comment["url"]
@@ -728,16 +763,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn finds_sticky_comment_by_marker() {
+    fn finds_sticky_comment_by_marker_and_author() {
         let comments = vec![
-            json!({"body": "unrelated comment"}),
-            json!({"body": "quoting the `<!-- marker -->` trick", "url": "http://c/2"}),
-            json!({"body": "<!-- marker -->\nreport", "url": "http://c/3"}),
+            json!({"body": "unrelated comment", "user": {"login": "bot"}}),
+            json!({"body": "quoting the `<!-- marker -->` trick", "url": "http://c/2", "user": {"login": "bot"}}),
+            json!({"body": "<!-- marker -->\nreport", "url": "http://c/3", "user": {"login": "bot"}}),
             json!({"no_body": true}),
         ];
-        let found = find_sticky_comment(&comments, "<!-- marker -->").unwrap();
+        let found = find_sticky_comment(&comments, "<!-- marker -->", "bot").unwrap();
         assert_eq!(found["url"], "http://c/3");
-        assert!(find_sticky_comment(&comments, "<!-- other -->").is_none());
+        assert!(find_sticky_comment(&comments, "<!-- other -->", "bot").is_none());
+    }
+
+    #[test]
+    fn ignores_marker_match_from_an_untrusted_author() {
+        // Anyone who can comment on a PR could post a body starting with
+        // the marker; without checking the author, this would be
+        // indistinguishable from a genuine report.
+        let comments = vec![
+            json!({"body": "<!-- marker -->\nforged report", "url": "http://c/1", "user": {"login": "attacker"}}),
+        ];
+        assert!(find_sticky_comment(&comments, "<!-- marker -->", "bot").is_none());
     }
 
     #[test]

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -65,22 +65,28 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
         .and_then(|pull| pull["number"].as_u64())
 }
 
-/// Returns whether a merge commit whose first parent has tree
-/// `parent_tree_sha` landed via rebase-and-merge, given `pr_commits` (the
-/// PR's own commits, oldest first, as returned by the GitHub API).
+/// Returns whether a merge commit whose first parent has author identity
+/// `parent_author` (the `commit.author` object: name, email, and date)
+/// landed via rebase-and-merge, given `pr_commits` (the PR's own commits,
+/// oldest first, as returned by the GitHub API).
 ///
-/// A rebase's merge commit has as its parent a content-identical replay of
-/// the PR's own second-to-last commit -- same tree, different sha, since
-/// rebasing changes parent linkage (and thus the commit hash) without
-/// touching content. A squash (or a single fast-forwarded commit) instead
-/// has a parent that predates the PR entirely, with an unrelated tree.
-/// Comparing trees rather than the commit message (which a maintainer can
-/// edit after the fact) makes this immune to that kind of drift.
+/// A clean git rebase preserves each commit's author name, email, and
+/// author date exactly -- only the committer (and committer date) change,
+/// since the committer becomes GitHub's merge machinery at merge time.
+/// Author identity is a reliable signal even when the PR's branch was
+/// based on an older point in the base branch's history: unlike a tree
+/// comparison, it doesn't depend on the base being unchanged since the PR
+/// branched, only on the rebase itself being clean. A tree comparison was
+/// tried and discarded for exactly this reason: a real rebase reapplies
+/// each commit's diff onto the new base, so its tree differs from the
+/// original source commit's whenever the base actually changed in
+/// between -- the very case this needs to detect.
 ///
-/// This heuristic can still be misled: if the PR's commits before the
-/// last happen to net to no tree change (e.g. an add followed by a
-/// revert), the pre-PR base tree can coincidentally equal the
-/// second-to-last commit's tree, misclassifying a squash as a rebase.
+/// A squash (or a single fast-forwarded commit) instead has a parent that
+/// predates the PR entirely, authored by whoever committed to the base
+/// branch at that point -- vanishingly unlikely to coincidentally match
+/// this PR's own second-to-last commit's author identity and timestamp.
+///
 /// Callers should only reach for this after a direct one-hop check
 /// against `payload.base_sha` has already failed -- that check is exact
 /// and always correct when it succeeds, so this is only ever asked to
@@ -90,11 +96,11 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
 /// A single-commit PR is excluded: squash and rebase are indistinguishable
 /// for it (both land as exactly one commit), so there's nothing to tell
 /// apart.
-fn merge_looks_rebased(parent_tree_sha: &str, pr_commits: &[Value]) -> bool {
+fn merge_looks_rebased(parent_author: &Value, pr_commits: &[Value]) -> bool {
     let Some(second_to_last) = pr_commits.len().checked_sub(2).map(|i| &pr_commits[i]) else {
         return false;
     };
-    second_to_last["commit"]["tree"]["sha"].as_str() == Some(parent_tree_sha)
+    &second_to_last["commit"]["author"] == parent_author
 }
 
 /// Returns whether `payload` was tested against exactly the base state the
@@ -408,12 +414,12 @@ impl GithubPrReporter {
                 Some((sha, parent_sha))
             })
             .collect();
-        let tree_of: HashMap<&str, &str> = commits
+        let author_of: HashMap<&str, &Value> = commits
             .iter()
             .filter_map(|commit| {
                 let sha = commit["sha"].as_str()?;
-                let tree_sha = commit["commit"]["tree"]["sha"].as_str()?;
-                Some((sha, tree_sha))
+                let author = commit["commit"].get("author")?;
+                Some((sha, author))
             })
             .collect();
 
@@ -439,14 +445,14 @@ impl GithubPrReporter {
             // Try the direct parent first: it's an exact sha comparison,
             // so a match is always correct regardless of merge strategy,
             // with no extra API calls. Only fall back to resolving the
-            // full landed span -- which relies on a tree-based heuristic
-            // that a coincidental no-net-change commit could mislead --
-            // when this doesn't already settle it.
+            // full landed span -- which relies on an author-based
+            // heuristic that could in principle be misled by coincidence
+            // -- when this doesn't already settle it.
             let is_fresh = if baseline_is_fresh(sha, 1, &parent_of, &payload) {
                 true
             } else {
                 let commit_count = self
-                    .resolve_landed_commit_count(&client, &tree_of, commit, pr_number)
+                    .resolve_landed_commit_count(&client, &author_of, commit, pr_number)
                     .await?;
                 baseline_is_fresh(sha, commit_count, &parent_of, &payload)
             };
@@ -565,13 +571,13 @@ impl GithubPrReporter {
     /// commit, regardless of how many source commits the PR had, or the
     /// PR's full source commit count for rebase-and-merge, which replays
     /// every commit individually. See [`merge_looks_rebased`] for how
-    /// those two cases are told apart. `tree_of` should map each
-    /// base-branch commit's sha to its own tree sha, built from the
-    /// already-fetched commit history.
+    /// those two cases are told apart. `author_of` should map each
+    /// base-branch commit's sha to its own `commit.author` object, built
+    /// from the already-fetched commit history.
     async fn resolve_landed_commit_count(
         &self,
         client: &Client,
-        tree_of: &HashMap<&str, &str>,
+        author_of: &HashMap<&str, &Value>,
         merge_commit: &Value,
         pr_number: u64,
     ) -> Result<u64> {
@@ -586,15 +592,15 @@ impl GithubPrReporter {
         let Some(parent_sha) = merge_commit["parents"][0]["sha"].as_str() else {
             return Ok(1);
         };
-        let parent_tree_sha = match tree_of.get(parent_sha) {
-            Some(&tree_sha) => tree_sha.to_string(),
+        let parent_author = match author_of.get(parent_sha) {
+            Some(&author) => author.clone(),
             // The parent falls outside the fetched commit history (the
             // candidate sits at the edge of the lookback window); fetch
             // it directly rather than skip the check.
-            None => self.fetch_commit_tree_sha(client, parent_sha).await?,
+            None => self.fetch_commit_author(client, parent_sha).await?,
         };
         let pr_commits = self.fetch_pr_commits(client, pr_number).await?;
-        if merge_looks_rebased(&parent_tree_sha, &pr_commits) {
+        if merge_looks_rebased(&parent_author, &pr_commits) {
             Ok(pr_commits.len() as u64)
         } else {
             Ok(1)
@@ -616,17 +622,18 @@ impl GithubPrReporter {
             .await
     }
 
-    /// Fetches the tree sha of a single commit.
-    async fn fetch_commit_tree_sha(&self, client: &Client, sha: &str) -> Result<String> {
+    /// Fetches the `commit.author` object of a single commit.
+    async fn fetch_commit_author(&self, client: &Client, sha: &str) -> Result<Value> {
         let url = format!(
             "{}/repos/{}/commits/{sha}",
             self.config.api_base_url, self.config.repo
         );
         let commit = self.get_json(client, &url, &[], "commit").await?;
-        commit["commit"]["tree"]["sha"]
-            .as_str()
-            .map(str::to_string)
-            .ok_or_else(|| anyhow!("commit response did not include tree sha"))
+        let author = commit["commit"]["author"].clone();
+        if author.is_null() {
+            bail!("commit response did not include author");
+        }
+        Ok(author)
     }
 
     /// Fetches `url` and decodes the response as JSON. `query` is appended
@@ -752,35 +759,44 @@ mod tests {
         }
     }
 
-    fn pr_commit_with_tree(tree_sha: &str) -> Value {
-        json!({"commit": {"tree": {"sha": tree_sha}}})
+    fn pr_commit_with_author(name: &str, date: &str) -> Value {
+        json!({"commit": {"author": {"name": name, "email": "a@example.com", "date": date}}})
     }
 
     #[test]
-    fn merge_looks_rebased_when_parent_tree_matches_second_to_last_commit() {
+    fn merge_looks_rebased_when_parent_author_matches_second_to_last_commit() {
         let pr_commits = vec![
-            pr_commit_with_tree("tree1"),
-            pr_commit_with_tree("tree2"),
-            pr_commit_with_tree("tree3"),
+            pr_commit_with_author("alice", "2026-01-01T00:00:00Z"),
+            pr_commit_with_author("alice", "2026-01-02T00:00:00Z"),
+            pr_commit_with_author("alice", "2026-01-03T00:00:00Z"),
         ];
-        assert!(merge_looks_rebased("tree2", &pr_commits));
+        let parent_author =
+            pr_commit_with_author("alice", "2026-01-02T00:00:00Z")["commit"]["author"].clone();
+        assert!(merge_looks_rebased(&parent_author, &pr_commits));
     }
 
     #[test]
-    fn merge_does_not_look_rebased_when_parent_tree_predates_the_pr() {
+    fn merge_does_not_look_rebased_when_parent_author_predates_the_pr() {
         // A squash (or standard merge) commit's parent is the base tip
-        // from before the PR touched anything, with a tree unrelated to
-        // any of the PR's own commits.
-        let pr_commits = vec![pr_commit_with_tree("tree1"), pr_commit_with_tree("tree2")];
-        assert!(!merge_looks_rebased("unrelated-tree", &pr_commits));
+        // from before the PR touched anything, authored by whoever
+        // committed to the base branch at that point.
+        let pr_commits = vec![
+            pr_commit_with_author("alice", "2026-01-01T00:00:00Z"),
+            pr_commit_with_author("alice", "2026-01-02T00:00:00Z"),
+        ];
+        let parent_author =
+            pr_commit_with_author("bob", "2025-06-01T00:00:00Z")["commit"]["author"].clone();
+        assert!(!merge_looks_rebased(&parent_author, &pr_commits));
     }
 
     #[test]
     fn merge_does_not_look_rebased_for_a_single_commit_pr() {
         // Squash and rebase are indistinguishable for a single-commit PR
         // -- both land as exactly one commit -- so this is never "rebased".
-        let pr_commits = vec![pr_commit_with_tree("tree1")];
-        assert!(!merge_looks_rebased("tree1", &pr_commits));
+        let pr_commits = vec![pr_commit_with_author("alice", "2026-01-01T00:00:00Z")];
+        let parent_author =
+            pr_commit_with_author("alice", "2026-01-01T00:00:00Z")["commit"]["author"].clone();
+        assert!(!merge_looks_rebased(&parent_author, &pr_commits));
     }
 
     #[test]

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -606,18 +606,28 @@ impl GithubPrReporter {
         // CI, where the job-level timeout covers it.
         let client = Client::new();
 
-        // A concurrent push, or a manual re-run of an older completed
-        // workflow run, can post after a newer push has already been
-        // tested and posted; the workflow's concurrency cancellation only
-        // cancels *overlapping* runs, so it doesn't catch either case. If
-        // the PR has since moved past the commit this run tested, these
-        // results are superseded, and posting them would silently
-        // overwrite a fresher report with stale data sharing the same
-        // base_sha (undetectable by baseline validation, which doesn't
-        // track head identity).
-        if let Some(tested_head) = &self.config.head_sha {
-            let current_head = self.fetch_pr_head(&client, self.config.pr_number).await?;
-            if &current_head != tested_head {
+        // A newer push, the PR being reopened, or a manual re-run of an
+        // older completed workflow run can all post after this run
+        // started. If the PR's head or base has since moved past what
+        // this run actually tested, these results are superseded: posting
+        // them would silently overwrite a fresher report with stale data.
+        // A stale base is just as important to catch as a stale head --
+        // e.g. a reopened-PR run posting fresh results against a newer
+        // base, later overwritten by a rerun of the original, older-base
+        // event, which still has the same (unchanged) head and so would
+        // pass a head-only check.
+        if self.config.head_sha.is_some() || self.config.base_sha.is_some() {
+            let (current_head, current_base) = self
+                .fetch_pr_head_and_base(&client, self.config.pr_number)
+                .await?;
+            if let Some(tested_head) = &self.config.head_sha
+                && current_head != *tested_head
+            {
+                return Ok(());
+            }
+            if let Some(tested_base) = &self.config.base_sha
+                && current_base != *tested_base
+            {
                 return Ok(());
             }
         }
@@ -675,17 +685,26 @@ impl GithubPrReporter {
             .await
     }
 
-    /// Fetches the PR's current head commit sha, live.
-    async fn fetch_pr_head(&self, client: &Client, pr_number: u64) -> Result<String> {
+    /// Fetches the PR's current head and base commit shas, live.
+    async fn fetch_pr_head_and_base(
+        &self,
+        client: &Client,
+        pr_number: u64,
+    ) -> Result<(String, String)> {
         let url = format!(
             "{}/repos/{}/pulls/{pr_number}",
             self.config.api_base_url, self.config.repo
         );
         let pr = self.get_json(client, &url, &[], "pull request").await?;
-        pr["head"]["sha"]
+        let head = pr["head"]["sha"]
             .as_str()
             .map(str::to_string)
-            .ok_or_else(|| anyhow!("pull request response did not include head.sha"))
+            .ok_or_else(|| anyhow!("pull request response did not include head.sha"))?;
+        let base = pr["base"]["sha"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("pull request response did not include base.sha"))?;
+        Ok((head, base))
     }
 
     /// Returns the number of commits `merge_commit` actually landed on the

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -47,15 +47,36 @@ fn first_merged_pr(pulls: &[Value], base_branch: &str) -> Option<u64> {
         .and_then(|pull| pull["number"].as_u64())
 }
 
-/// Returns the report header identifying what was benchmarked.
-fn format_header(commit_hash: Option<&str>) -> String {
-    match commit_hash {
-        Some(hash) => {
-            let short_commit: String = hash.chars().take(8).collect();
-            format!("**Commit**: {short_commit}")
-        }
+/// Returns the first 8 characters of a commit hash.
+fn short_hash(hash: &str) -> String {
+    hash.chars().take(8).collect()
+}
+
+/// Returns the report header identifying what was benchmarked and which
+/// baseline it is compared against.
+fn format_header(
+    commit_hash: Option<&str>,
+    baseline: Option<&BaselineReport>,
+    base_branch: Option<&str>,
+) -> String {
+    let mut lines = vec![match commit_hash {
+        Some(hash) => format!("**Commit**: {}", short_hash(hash)),
         None => "**Local execution**".to_string(),
+    }];
+    match (baseline, base_branch) {
+        (Some(baseline), _) => lines.push(format!(
+            "**Baseline**: #{} ({})",
+            baseline.pr_number,
+            short_hash(&baseline.commit_hash)
+        )),
+        // A base branch was configured but yielded no baseline; say so to
+        // distinguish "nothing to compare against yet" from a broken lookup.
+        (None, Some(base_branch)) => {
+            lines.push(format!("**Baseline**: none found on `{base_branch}`"))
+        }
+        (None, None) => {}
     }
+    lines.join("\n")
 }
 
 /// Default `User-Agent` header sent with GitHub API requests.
@@ -206,13 +227,23 @@ impl GithubPrReporter {
     }
 
     /// Renders the results and posts them to the PR, updating the existing
-    /// sticky comment if one is found. The posted comment also embeds the
-    /// results as a hidden machine-readable payload, which is what later
-    /// runs read back as their baseline.
-    pub async fn post_report(&self, results: &[ZkVmResults]) -> Result<()> {
-        let header = format_header(self.config.commit_hash.as_deref());
+    /// sticky comment if one is found, with per-program deltas when a
+    /// `baseline` is given. The posted comment also embeds the results as a
+    /// hidden machine-readable payload, which is what later runs read back
+    /// as their baseline.
+    pub async fn post_report(
+        &self,
+        results: &[ZkVmResults],
+        baseline: Option<&BaselineReport>,
+    ) -> Result<()> {
+        let header = format_header(
+            self.config.commit_hash.as_deref(),
+            baseline,
+            self.config.base_branch.as_deref(),
+        );
         let payload = ReportPayload::from(results).embed()?;
-        let report_text = format!("{header}\n{}\n{payload}", render_report(results));
+        let report = render_report(results, baseline.map(|baseline| &baseline.payload));
+        let report_text = format!("{header}\n{report}\n{payload}");
         self.post(&report_text).await
     }
 

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -65,6 +65,35 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
         .and_then(|pull| pull["number"].as_u64())
 }
 
+/// Returns whether `payload` was tested against exactly the base state
+/// `commit` (the candidate's merge commit) landed on, i.e. `payload.base_sha`
+/// matches `commit`'s first parent.
+///
+/// If the base branch advanced after the candidate PR's last CI run but
+/// before it merged, `payload.base_sha` names a commit that is no longer
+/// the merge's parent; using such a payload as a baseline would silently
+/// attribute the base branch's intervening changes to whichever PR is
+/// compared against it next. A payload with no `base_sha` (e.g. posted
+/// before this field existed) can't be verified and is treated as stale.
+///
+/// This assumes the merge landed as a squash or a standard two-parent
+/// merge commit, where `parents[0]` is the base tip immediately before the
+/// merge.
+///
+/// TODO: rebase-and-merge instead replays the PR's commits individually,
+/// so `parents[0]` of the last one is another of the PR's own commits, not
+/// the pre-merge base; this check would then reject even a fresh candidate
+/// on repositories using that merge strategy.
+fn baseline_is_fresh(commit: &Value, payload: &ReportPayload) -> bool {
+    let Some(tested_base_sha) = payload.base_sha.as_deref() else {
+        return false;
+    };
+    let Some(base_parent_sha) = commit["parents"][0]["sha"].as_str() else {
+        return false;
+    };
+    tested_base_sha == base_parent_sha
+}
+
 /// Returns the first 8 characters of a commit hash.
 fn short_hash(hash: &str) -> String {
     hash.chars().take(8).collect()
@@ -333,6 +362,9 @@ impl GithubPrReporter {
             else {
                 continue;
             };
+            if !baseline_is_fresh(commit, &payload) {
+                continue;
+            }
             return Ok(Some(BaselineReport {
                 pr_number,
                 commit_hash: sha.to_string(),
@@ -344,9 +376,12 @@ impl GithubPrReporter {
 
     /// Renders the results and posts them to the PR, updating the existing
     /// sticky comment if one is found, with per-program deltas when a
-    /// `baseline` is given. The posted comment also embeds the results as a
-    /// hidden machine-readable payload, which is what later runs read back
-    /// as their baseline.
+    /// `baseline` is given. The posted comment also embeds the results,
+    /// along with the base commit resolved by `anchor`, as a hidden
+    /// machine-readable payload; this is what later runs read back as
+    /// their baseline, and `anchor`'s base commit is what lets them detect
+    /// a candidate whose base branch moved after it was tested (see
+    /// [`Self::fetch_baseline`]).
     ///
     /// `baseline_lookup_failed` should be set when the caller's
     /// [`Self::fetch_baseline`] call returned `Err` rather than `Ok(None)`,
@@ -357,6 +392,7 @@ impl GithubPrReporter {
         results: &[ZkVmResults],
         baseline: Option<&BaselineReport>,
         baseline_lookup_failed: bool,
+        anchor: Option<&BaselineAnchor>,
     ) -> Result<()> {
         let no_baseline_reason = if baseline_lookup_failed {
             NoBaselineReason::LookupFailed
@@ -370,7 +406,8 @@ impl GithubPrReporter {
             baseline,
             no_baseline_reason,
         );
-        let payload = ReportPayload::from(results).embed()?;
+        let payload =
+            ReportPayload::new(results, anchor.map(|anchor| anchor.base_sha.clone())).embed()?;
         let report = render_report(results, baseline.map(|baseline| &baseline.payload));
         let report_text = format!("{header}\n{report}\n{payload}");
         self.post(&report_text).await
@@ -549,5 +586,42 @@ mod tests {
         assert_eq!(find_pr_for_merge_commit(&merged_pulls, "abc123"), Some(3));
         assert_eq!(find_pr_for_merge_commit(&merged_pulls, "def456"), Some(2));
         assert_eq!(find_pr_for_merge_commit(&merged_pulls, "missing"), None);
+    }
+
+    fn payload_with_base_sha(base_sha: Option<&str>) -> ReportPayload {
+        ReportPayload {
+            base_sha: base_sha.map(str::to_string),
+            zkvms: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn baseline_is_fresh_when_tested_base_matches_merge_parent() {
+        let commit = json!({"sha": "merge1", "parents": [{"sha": "base1"}]});
+        let payload = payload_with_base_sha(Some("base1"));
+        assert!(baseline_is_fresh(&commit, &payload));
+    }
+
+    #[test]
+    fn baseline_is_stale_when_base_advanced_before_merge() {
+        // The candidate was last tested against `base1`, but by the time it
+        // merged the base branch had moved on to `base2`.
+        let commit = json!({"sha": "merge1", "parents": [{"sha": "base2"}]});
+        let payload = payload_with_base_sha(Some("base1"));
+        assert!(!baseline_is_fresh(&commit, &payload));
+    }
+
+    #[test]
+    fn baseline_is_stale_without_a_tested_base_sha() {
+        let commit = json!({"sha": "merge1", "parents": [{"sha": "base1"}]});
+        let payload = payload_with_base_sha(None);
+        assert!(!baseline_is_fresh(&commit, &payload));
+    }
+
+    #[test]
+    fn baseline_is_stale_without_commit_parents() {
+        let commit = json!({"sha": "merge1", "parents": []});
+        let payload = payload_with_base_sha(Some("base1"));
+        assert!(!baseline_is_fresh(&commit, &payload));
     }
 }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -324,6 +324,9 @@ impl GithubPrReporter {
         if config.api_base_url.trim().is_empty() {
             bail!("github API base url is required");
         }
+        if config.expected_comment_author.trim().is_empty() {
+            bail!("expected comment author is required");
+        }
         config.api_base_url = config.api_base_url.trim_end_matches('/').to_string();
         Ok(Self { config })
     }
@@ -761,6 +764,18 @@ impl GithubPrReporter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_a_blank_expected_comment_author() {
+        let config = GithubPrReporterConfig {
+            repo: "owner/repo".to_string(),
+            token: "token".to_string(),
+            marker: "marker".to_string(),
+            expected_comment_author: "  ".to_string(),
+            ..Default::default()
+        };
+        assert!(GithubPrReporter::new(config).is_err());
+    }
 
     #[test]
     fn finds_sticky_comment_by_marker_and_author() {

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -150,6 +150,13 @@ pub struct GithubPrReporterConfig {
     /// [`DEFAULT_BASELINE_COMMIT_LOOKBACK`] for how the window relates to
     /// the repository's merge strategy.
     pub baseline_commit_lookback: usize,
+    /// Base branch ref name to anchor the baseline commit walk to, taken
+    /// from the triggering event rather than resolved live. `None` falls
+    /// back to a live lookup of the PR's current base, e.g. outside CI.
+    pub base_ref: Option<String>,
+    /// Base branch commit SHA to anchor the baseline commit walk to. See
+    /// [`Self::base_ref`].
+    pub base_sha: Option<String>,
 }
 
 impl Default for GithubPrReporterConfig {
@@ -163,6 +170,8 @@ impl Default for GithubPrReporterConfig {
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             commit_hash: None,
             baseline_commit_lookback: DEFAULT_BASELINE_COMMIT_LOOKBACK,
+            base_ref: None,
+            base_sha: None,
         }
     }
 }
@@ -178,6 +187,8 @@ impl fmt::Debug for GithubPrReporterConfig {
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
             .field("baseline_commit_lookback", &self.baseline_commit_lookback)
+            .field("base_ref", &self.base_ref)
+            .field("base_sha", &self.base_sha)
             .finish()
     }
 }
@@ -214,19 +225,27 @@ impl GithubPrReporter {
     }
 
     /// Resolves the anchor for the baseline commit walk: the PR's base
-    /// branch and the commit it currently points to. Call this before doing
-    /// any long-running work (e.g. before running benchmarks) and pass the
+    /// branch and the commit to walk back from. Call this before doing any
+    /// long-running work (e.g. before running benchmarks) and pass the
     /// result to [`Self::fetch_baseline`] once that work is done.
     ///
-    /// Resolving this late instead (i.e. inside `fetch_baseline`, after
-    /// benchmarks run) would let another PR merging into the base branch
-    /// while this job is queued or executing shift the walk to start from
-    /// that newer tip, selecting a baseline whose changes are absent from
-    /// what was actually tested. Returns `None` when the lookback is zero,
-    /// so callers don't pay for a PR fetch that would go unused.
+    /// Prefers `config.base_ref`/`config.base_sha`, sourced from the
+    /// triggering event and fixed for the run, over a live PR lookup:
+    /// resolving live is racy even when done up front, since the base
+    /// branch can advance between the event firing (what `GITHUB_SHA` was
+    /// actually built from) and this call running. The live lookup remains
+    /// as a fallback for non-CI use. Returns `None` when the lookback is
+    /// zero, so callers don't pay for a PR fetch that would go unused.
     pub async fn resolve_baseline_anchor(&self) -> Result<Option<BaselineAnchor>> {
         if self.config.baseline_commit_lookback == 0 {
             return Ok(None);
+        }
+
+        if let (Some(base_ref), Some(base_sha)) = (&self.config.base_ref, &self.config.base_sha) {
+            return Ok(Some(BaselineAnchor {
+                base_ref: base_ref.clone(),
+                base_sha: base_sha.clone(),
+            }));
         }
 
         let client = Client::new();

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 use anyhow::{Result, anyhow, bail};
 use reqwest::{Client, RequestBuilder};
@@ -331,29 +334,61 @@ impl GithubPrReporter {
             )
             .await?;
 
+        let candidate_shas: HashSet<&str> = commits
+            .iter()
+            .filter_map(|commit| commit["sha"].as_str())
+            .collect();
+
         let pulls_url = format!(
             "{}/repos/{}/pulls",
             self.config.api_base_url, self.config.repo
         );
-        // `state=closed` includes closed-but-unmerged PRs alongside merged
-        // ones, so this can't be capped to `lookback`: a burst of
-        // recently-updated rejected PRs would crowd out the merged PR that
-        // actually matches one of the fetched commits. Always search at
-        // least a full page.
-        let merged_pulls = self
-            .get_json_array_paginated(
-                &client,
-                &pulls_url,
-                &[
-                    ("base", anchor.base_ref.as_str()),
-                    ("state", "closed"),
-                    ("sort", "updated"),
-                    ("direction", "desc"),
-                ],
-                "merged pull requests",
-                lookback.max(100),
-            )
-            .await?;
+        // `sort=updated` has no reliable relationship to merge order: a PR
+        // merged long ago can resurface at the top of this list from a
+        // single new comment, while an unrelated rejected PR can sit there
+        // indefinitely. A fixed page cap can therefore still miss the
+        // merged PR for a commit inside our lookback window; keep paging
+        // until every candidate commit has been matched to a PR, or the
+        // endpoint itself runs out.
+        //
+        // TODO: a base branch commit that was never merged in via a PR
+        // (e.g. a direct push) can never be matched, which degrades this
+        // to fetching every closed PR against `base_ref`. Acceptable for
+        // now: base branches are typically protected to require PRs.
+        let mut merged_pulls: Vec<Value> = Vec::new();
+        let mut matched_shas: HashSet<String> = HashSet::new();
+        let mut page = 1u32;
+        loop {
+            let page_str = page.to_string();
+            let batch = self
+                .get_json_array(
+                    &client,
+                    &pulls_url,
+                    &[
+                        ("base", anchor.base_ref.as_str()),
+                        ("state", "closed"),
+                        ("sort", "updated"),
+                        ("direction", "desc"),
+                        ("per_page", "100"),
+                        ("page", &page_str),
+                    ],
+                    "merged pull requests",
+                )
+                .await?;
+            let batch_len = batch.len();
+            for pull in &batch {
+                if let Some(sha) = pull["merge_commit_sha"].as_str()
+                    && candidate_shas.contains(sha)
+                {
+                    matched_shas.insert(sha.to_string());
+                }
+            }
+            merged_pulls.extend(batch);
+            if batch_len < 100 || matched_shas.len() == candidate_shas.len() {
+                break;
+            }
+            page += 1;
+        }
 
         let parent_of: HashMap<&str, &str> = commits
             .iter()

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -206,12 +206,18 @@ impl GithubPrReporter {
         // TODO: lookbacks above 100 are silently capped by the GitHub API,
         // which serves at most one page of commits; paginate to support
         // larger windows.
+        let lookback = self.config.baseline_commit_lookback.to_string();
         let commits_url = format!(
-            "{}/repos/{}/commits?sha={base_branch}&per_page={}",
-            self.config.api_base_url, self.config.repo, self.config.baseline_commit_lookback
+            "{}/repos/{}/commits",
+            self.config.api_base_url, self.config.repo
         );
         let commits = self
-            .get_json_array(&client, &commits_url, "base branch commits")
+            .get_json_array(
+                &client,
+                &commits_url,
+                &[("sha", base_branch.as_str()), ("per_page", &lookback)],
+                "base branch commits",
+            )
             .await?;
 
         for commit in &commits {
@@ -223,7 +229,7 @@ impl GithubPrReporter {
                 self.config.api_base_url, self.config.repo
             );
             let pulls = self
-                .get_json_array(&client, &pulls_url, "associated pull requests")
+                .get_json_array(&client, &pulls_url, &[], "associated pull requests")
                 .await?;
             let Some(pr_number) = first_merged_pr(&pulls, &base_branch) else {
                 continue;
@@ -313,7 +319,7 @@ impl GithubPrReporter {
             "{}/repos/{}/pulls/{}",
             self.config.api_base_url, self.config.repo, self.config.pr_number
         );
-        let pr = self.get_json(client, &url, "pull request").await?;
+        let pr = self.get_json(client, &url, &[], "pull request").await?;
         pr["base"]["ref"]
             .as_str()
             .map(str::to_string)
@@ -333,13 +339,26 @@ impl GithubPrReporter {
     }
 
     async fn fetch_comments(&self, client: &Client, pr_number: u64) -> Result<Vec<Value>> {
-        self.get_json_array(client, &self.comments_url(pr_number), "PR comments")
+        self.get_json_array(client, &self.comments_url(pr_number), &[], "PR comments")
             .await
     }
 
-    /// Fetches `url` and decodes the response as JSON.
-    async fn get_json(&self, client: &Client, url: &str, what: &str) -> Result<Value> {
-        let response = self.set_github_headers(client.get(url)).send().await?;
+    /// Fetches `url` and decodes the response as JSON. `query` is appended
+    /// as URL-encoded query parameters rather than interpolated into
+    /// `url` directly, so values with URL-significant characters (e.g. a
+    /// branch name like `release#1`) can't truncate or redirect the
+    /// request.
+    async fn get_json(
+        &self,
+        client: &Client,
+        url: &str,
+        query: &[(&str, &str)],
+        what: &str,
+    ) -> Result<Value> {
+        let response = self
+            .set_github_headers(client.get(url).query(query))
+            .send()
+            .await?;
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
@@ -355,9 +374,16 @@ impl GithubPrReporter {
             .map_err(|e| anyhow!("failed to decode {what} response: {e}"))
     }
 
-    /// Fetches `url` and decodes the response as a JSON array.
-    async fn get_json_array(&self, client: &Client, url: &str, what: &str) -> Result<Vec<Value>> {
-        match self.get_json(client, url, what).await? {
+    /// Fetches `url` and decodes the response as a JSON array. See
+    /// [`Self::get_json`] for `query`.
+    async fn get_json_array(
+        &self,
+        client: &Client,
+        url: &str,
+        query: &[(&str, &str)],
+        what: &str,
+    ) -> Result<Vec<Value>> {
+        match self.get_json(client, url, query, what).await? {
             Value::Array(items) => Ok(items),
             _ => bail!("expected a JSON array in {what} response"),
         }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -65,16 +65,40 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
         .and_then(|pull| pull["number"].as_u64())
 }
 
+/// Returns whether `merge_commit` unambiguously landed as a single commit
+/// on the base branch, regardless of how many source commits the PR had:
+///
+/// - A two-parent commit is a standard merge commit, where `parents[0]` is always the base tip
+///   immediately before the merge.
+/// - A message containing `(#<pr_number>)` matches GitHub's default squash-commit title (`<PR
+///   title> (#<number>)`), which also always lands as a single commit no matter how many commits
+///   the PR had.
+///
+/// Only when neither holds does the PR's own source commit count become
+/// relevant, for the remaining case: rebase-and-merge, which replays every
+/// source commit individually.
+fn merge_landed_as_one_commit(merge_commit: &Value, pr_number: u64) -> bool {
+    let is_standard_merge = merge_commit["parents"]
+        .as_array()
+        .is_some_and(|parents| parents.len() == 2);
+    let squash_marker = format!("(#{pr_number})");
+    let looks_like_squash = merge_commit["commit"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains(&squash_marker));
+    is_standard_merge || looks_like_squash
+}
+
 /// Returns whether `payload` was tested against exactly the base state the
 /// candidate's commit span landed on.
 ///
 /// Walks back exactly `commit_count` first-parent hops from `merge_sha`
 /// (the candidate's merge commit) -- one hop per commit this PR actually
-/// contributed, whether that's a single squash/merge commit or every
-/// commit replayed by rebase-and-merge -- and checks whether the resulting
-/// commit is `payload.base_sha`. `parent_of` should map each base-branch
-/// commit's sha to its first parent's sha, built from the already-fetched
-/// commit history.
+/// landed on the base branch. Callers should pass 1 when
+/// [`merge_landed_as_one_commit`] holds and the PR's own source commit
+/// count only otherwise, for rebase-and-merge, which replays every source
+/// commit individually. `parent_of` should map each base-branch commit's
+/// sha to its first parent's sha, built from the already-fetched commit
+/// history.
 ///
 /// The walk must stop at exactly `commit_count` hops rather than
 /// continuing until *some* match turns up: the base branch's history is
@@ -392,12 +416,20 @@ impl GithubPrReporter {
             else {
                 continue;
             };
-            // Skip the extra API call below when there's nothing to
-            // validate against anyway.
+            // Skip the extra work below when there's nothing to validate
+            // against anyway.
             if payload.base_sha.is_none() {
                 continue;
             }
-            let commit_count = self.fetch_pr_commit_count(&client, pr_number).await?;
+            // The PR's own source commit count only matters for
+            // rebase-and-merge; skip that extra API call for the much
+            // more common squash/standard-merge case, where exactly one
+            // commit lands regardless of source commit count.
+            let commit_count = if merge_landed_as_one_commit(commit, pr_number) {
+                1
+            } else {
+                self.fetch_pr_commit_count(&client, pr_number).await?
+            };
             if !baseline_is_fresh(sha, commit_count, &parent_of, &payload) {
                 continue;
             }
@@ -644,6 +676,35 @@ mod tests {
             base_sha: base_sha.map(str::to_string),
             zkvms: Vec::new(),
         }
+    }
+
+    #[test]
+    fn merge_landed_as_one_commit_for_a_two_parent_merge() {
+        let commit = json!({
+            "parents": [{"sha": "base1"}, {"sha": "head1"}],
+            "commit": {"message": "Merge pull request #42 from user/branch"},
+        });
+        assert!(merge_landed_as_one_commit(&commit, 42));
+    }
+
+    #[test]
+    fn merge_landed_as_one_commit_for_githubs_default_squash_message() {
+        let commit = json!({
+            "parents": [{"sha": "base1"}],
+            "commit": {"message": "some change (#42)"},
+        });
+        assert!(merge_landed_as_one_commit(&commit, 42));
+    }
+
+    #[test]
+    fn merge_did_not_land_as_one_commit_for_a_rebased_commit() {
+        // One parent, and the message doesn't reference this PR at all
+        // (it's the original commit message carried over by the rebase).
+        let commit = json!({
+            "parents": [{"sha": "rebased2"}],
+            "commit": {"message": "some change"},
+        });
+        assert!(!merge_landed_as_one_commit(&commit, 42));
     }
 
     #[test]

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -259,6 +259,19 @@ pub struct GithubPrReporterConfig {
     /// forge a fake report by posting a comment starting with the hidden
     /// marker. See [`DEFAULT_EXPECTED_COMMENT_AUTHOR`].
     pub expected_comment_author: String,
+    /// The PR head commit this run tested, taken from the triggering
+    /// event. `None` disables the supersession check when posting (e.g.
+    /// outside CI).
+    ///
+    /// Concurrency cancellation in the workflow only cancels *overlapping*
+    /// runs; it doesn't stop a manual re-run of an older, already-completed
+    /// run after a newer push has been tested and posted. Recording and
+    /// checking the tested head directly closes that gap: a run whose
+    /// tested head no longer matches the PR's current head knows it has
+    /// been superseded and skips posting, rather than overwriting a
+    /// fresher report with stale results that share the same base_sha and
+    /// would otherwise pass baseline validation undetected.
+    pub head_sha: Option<String>,
 }
 
 impl Default for GithubPrReporterConfig {
@@ -275,6 +288,7 @@ impl Default for GithubPrReporterConfig {
             base_ref: None,
             base_sha: None,
             expected_comment_author: DEFAULT_EXPECTED_COMMENT_AUTHOR.to_string(),
+            head_sha: None,
         }
     }
 }
@@ -293,6 +307,7 @@ impl fmt::Debug for GithubPrReporterConfig {
             .field("base_ref", &self.base_ref)
             .field("base_sha", &self.base_sha)
             .field("expected_comment_author", &self.expected_comment_author)
+            .field("head_sha", &self.head_sha)
             .finish()
     }
 }
@@ -551,6 +566,23 @@ impl GithubPrReporter {
         // fails on its own. Acceptable for now: this is expected to run in
         // CI, where the job-level timeout covers it.
         let client = Client::new();
+
+        // A concurrent push, or a manual re-run of an older completed
+        // workflow run, can post after a newer push has already been
+        // tested and posted; the workflow's concurrency cancellation only
+        // cancels *overlapping* runs, so it doesn't catch either case. If
+        // the PR has since moved past the commit this run tested, these
+        // results are superseded, and posting them would silently
+        // overwrite a fresher report with stale data sharing the same
+        // base_sha (undetectable by baseline validation, which doesn't
+        // track head identity).
+        if let Some(tested_head) = &self.config.head_sha {
+            let current_head = self.fetch_pr_head(&client, self.config.pr_number).await?;
+            if &current_head != tested_head {
+                return Ok(());
+            }
+        }
+
         let comments = self.fetch_comments(&client, self.config.pr_number).await?;
         let sticky_comment = find_sticky_comment(
             &comments,
@@ -602,6 +634,19 @@ impl GithubPrReporter {
     async fn fetch_comments(&self, client: &Client, pr_number: u64) -> Result<Vec<Value>> {
         self.get_json_array(client, &self.comments_url(pr_number), &[], "PR comments")
             .await
+    }
+
+    /// Fetches the PR's current head commit sha, live.
+    async fn fetch_pr_head(&self, client: &Client, pr_number: u64) -> Result<String> {
+        let url = format!(
+            "{}/repos/{}/pulls/{pr_number}",
+            self.config.api_base_url, self.config.repo
+        );
+        let pr = self.get_json(client, &url, &[], "pull request").await?;
+        pr["head"]["sha"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("pull request response did not include head.sha"))
     }
 
     /// Returns the number of commits `merge_commit` actually landed on the

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-};
+use std::{collections::HashMap, fmt};
 
 use anyhow::{Result, anyhow, bail};
 use reqwest::{Client, RequestBuilder};
@@ -337,61 +334,40 @@ impl GithubPrReporter {
             )
             .await?;
 
-        let candidate_shas: HashSet<&str> = commits
-            .iter()
-            .filter_map(|commit| commit["sha"].as_str())
-            .collect();
-
         let pulls_url = format!(
             "{}/repos/{}/pulls",
             self.config.api_base_url, self.config.repo
         );
-        // `sort=updated` has no reliable relationship to merge order: a PR
-        // merged long ago can resurface at the top of this list from a
-        // single new comment, while an unrelated rejected PR can sit there
-        // indefinitely. A fixed page cap can therefore still miss the
-        // merged PR for a commit inside our lookback window; keep paging
-        // until every candidate commit has been matched to a PR, or the
-        // endpoint itself runs out.
+        // `state=closed` includes closed-but-unmerged PRs alongside merged
+        // ones, and `sort=updated` has no reliable relationship to merge
+        // order -- a PR merged long ago can resurface at the top of this
+        // list from a single new comment, while an unrelated rejected PR
+        // can sit there indefinitely. This cap is therefore a bounded
+        // best-effort, not an exhaustive search: it can still miss the
+        // merged PR for a commit inside the lookback window if enough
+        // irrelevant closed PRs crowd it out.
         //
-        // TODO: a base branch commit that was never merged in via a PR
-        // (e.g. a direct push) can never be matched, which degrades this
-        // to fetching every closed PR against `base_ref`. Acceptable for
-        // now: base branches are typically protected to require PRs.
-        let mut merged_pulls: Vec<Value> = Vec::new();
-        let mut matched_shas: HashSet<String> = HashSet::new();
-        let mut page = 1u32;
-        loop {
-            let page_str = page.to_string();
-            let batch = self
-                .get_json_array(
-                    &client,
-                    &pulls_url,
-                    &[
-                        ("base", anchor.base_ref.as_str()),
-                        ("state", "closed"),
-                        ("sort", "updated"),
-                        ("direction", "desc"),
-                        ("per_page", "100"),
-                        ("page", &page_str),
-                    ],
-                    "merged pull requests",
-                )
-                .await?;
-            let batch_len = batch.len();
-            for pull in &batch {
-                if let Some(sha) = pull["merge_commit_sha"].as_str()
-                    && candidate_shas.contains(sha)
-                {
-                    matched_shas.insert(sha.to_string());
-                }
-            }
-            merged_pulls.extend(batch);
-            if batch_len < 100 || matched_shas.len() == candidate_shas.len() {
-                break;
-            }
-            page += 1;
-        }
+        // TODO: an exhaustive search (page until every commit in the
+        // window is accounted for) was tried and reverted: on a
+        // repository using rebase-and-merge, every commit but the last in
+        // each PR's span can never match any `merge_commit_sha`, which
+        // degenerated into paging through the entire closed-PR history on
+        // every run. Revisit if this cap turns out to miss baselines in
+        // practice.
+        let merged_pulls = self
+            .get_json_array_paginated(
+                &client,
+                &pulls_url,
+                &[
+                    ("base", anchor.base_ref.as_str()),
+                    ("state", "closed"),
+                    ("sort", "updated"),
+                    ("direction", "desc"),
+                ],
+                "merged pull requests",
+                lookback.max(100),
+            )
+            .await?;
 
         let parent_of: HashMap<&str, &str> = commits
             .iter()

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -65,27 +65,26 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
         .and_then(|pull| pull["number"].as_u64())
 }
 
-/// Returns whether `merge_commit` unambiguously landed as a single commit
-/// on the base branch, regardless of how many source commits the PR had:
+/// Returns whether a merge commit whose first parent has tree
+/// `parent_tree_sha` landed via rebase-and-merge, given `pr_commits` (the
+/// PR's own commits, oldest first, as returned by the GitHub API).
 ///
-/// - A two-parent commit is a standard merge commit, where `parents[0]` is always the base tip
-///   immediately before the merge.
-/// - A message containing `(#<pr_number>)` matches GitHub's default squash-commit title (`<PR
-///   title> (#<number>)`), which also always lands as a single commit no matter how many commits
-///   the PR had.
+/// A rebase's merge commit has as its parent a content-identical replay of
+/// the PR's own second-to-last commit -- same tree, different sha, since
+/// rebasing changes parent linkage (and thus the commit hash) without
+/// touching content. A squash (or a single fast-forwarded commit) instead
+/// has a parent that predates the PR entirely, with an unrelated tree.
+/// Comparing trees rather than the commit message (which a maintainer can
+/// edit after the fact) makes this immune to that kind of drift.
 ///
-/// Only when neither holds does the PR's own source commit count become
-/// relevant, for the remaining case: rebase-and-merge, which replays every
-/// source commit individually.
-fn merge_landed_as_one_commit(merge_commit: &Value, pr_number: u64) -> bool {
-    let is_standard_merge = merge_commit["parents"]
-        .as_array()
-        .is_some_and(|parents| parents.len() == 2);
-    let squash_marker = format!("(#{pr_number})");
-    let looks_like_squash = merge_commit["commit"]["message"]
-        .as_str()
-        .is_some_and(|message| message.contains(&squash_marker));
-    is_standard_merge || looks_like_squash
+/// A single-commit PR is excluded: squash and rebase are indistinguishable
+/// for it (both land as exactly one commit), so there's nothing to tell
+/// apart.
+fn merge_looks_rebased(parent_tree_sha: &str, pr_commits: &[Value]) -> bool {
+    let Some(second_to_last) = pr_commits.len().checked_sub(2).map(|i| &pr_commits[i]) else {
+        return false;
+    };
+    second_to_last["commit"]["tree"]["sha"].as_str() == Some(parent_tree_sha)
 }
 
 /// Returns whether `payload` was tested against exactly the base state the
@@ -93,12 +92,10 @@ fn merge_landed_as_one_commit(merge_commit: &Value, pr_number: u64) -> bool {
 ///
 /// Walks back exactly `commit_count` first-parent hops from `merge_sha`
 /// (the candidate's merge commit) -- one hop per commit this PR actually
-/// landed on the base branch. Callers should pass 1 when
-/// [`merge_landed_as_one_commit`] holds and the PR's own source commit
-/// count only otherwise, for rebase-and-merge, which replays every source
-/// commit individually. `parent_of` should map each base-branch commit's
-/// sha to its first parent's sha, built from the already-fetched commit
-/// history.
+/// landed on the base branch; see [`GithubPrReporter::resolve_landed_commit_count`]
+/// for how that count is determined. `parent_of` should map each
+/// base-branch commit's sha to its first parent's sha, built from the
+/// already-fetched commit history.
 ///
 /// The walk must stop at exactly `commit_count` hops rather than
 /// continuing until *some* match turns up: the base branch's history is
@@ -401,6 +398,14 @@ impl GithubPrReporter {
                 Some((sha, parent_sha))
             })
             .collect();
+        let tree_of: HashMap<&str, &str> = commits
+            .iter()
+            .filter_map(|commit| {
+                let sha = commit["sha"].as_str()?;
+                let tree_sha = commit["commit"]["tree"]["sha"].as_str()?;
+                Some((sha, tree_sha))
+            })
+            .collect();
 
         for commit in &commits {
             let Some(sha) = commit["sha"].as_str() else {
@@ -421,15 +426,9 @@ impl GithubPrReporter {
             if payload.base_sha.is_none() {
                 continue;
             }
-            // The PR's own source commit count only matters for
-            // rebase-and-merge; skip that extra API call for the much
-            // more common squash/standard-merge case, where exactly one
-            // commit lands regardless of source commit count.
-            let commit_count = if merge_landed_as_one_commit(commit, pr_number) {
-                1
-            } else {
-                self.fetch_pr_commit_count(&client, pr_number).await?
-            };
+            let commit_count = self
+                .resolve_landed_commit_count(&client, &tree_of, commit, pr_number)
+                .await?;
             if !baseline_is_fresh(sha, commit_count, &parent_of, &payload) {
                 continue;
             }
@@ -540,19 +539,73 @@ impl GithubPrReporter {
             .await
     }
 
-    /// Returns the number of commits in PR `pr_number`, used to bound
-    /// [`baseline_is_fresh`]'s parent walk to exactly that PR's own commit
-    /// span. The list-pulls endpoint used to build `merged_pulls` doesn't
-    /// include this count; only the single-PR endpoint does.
-    async fn fetch_pr_commit_count(&self, client: &Client, pr_number: u64) -> Result<u64> {
+    /// Returns the number of commits `merge_commit` actually landed on the
+    /// base branch: 1 for a squash merge or a standard two-parent merge
+    /// commit, regardless of how many source commits the PR had, or the
+    /// PR's full source commit count for rebase-and-merge, which replays
+    /// every commit individually. See [`merge_looks_rebased`] for how
+    /// those two cases are told apart. `tree_of` should map each
+    /// base-branch commit's sha to its own tree sha, built from the
+    /// already-fetched commit history.
+    async fn resolve_landed_commit_count(
+        &self,
+        client: &Client,
+        tree_of: &HashMap<&str, &str>,
+        merge_commit: &Value,
+        pr_number: u64,
+    ) -> Result<u64> {
+        // A two-parent merge commit is unambiguous: parents[0] is always
+        // the base tip immediately before the merge.
+        if merge_commit["parents"]
+            .as_array()
+            .is_some_and(|parents| parents.len() == 2)
+        {
+            return Ok(1);
+        }
+        let Some(parent_sha) = merge_commit["parents"][0]["sha"].as_str() else {
+            return Ok(1);
+        };
+        let parent_tree_sha = match tree_of.get(parent_sha) {
+            Some(&tree_sha) => tree_sha.to_string(),
+            // The parent falls outside the fetched commit history (the
+            // candidate sits at the edge of the lookback window); fetch
+            // it directly rather than skip the check.
+            None => self.fetch_commit_tree_sha(client, parent_sha).await?,
+        };
+        let pr_commits = self.fetch_pr_commits(client, pr_number).await?;
+        if merge_looks_rebased(&parent_tree_sha, &pr_commits) {
+            Ok(pr_commits.len() as u64)
+        } else {
+            Ok(1)
+        }
+    }
+
+    /// Fetches the commits of PR `pr_number`, oldest first.
+    ///
+    /// TODO: this endpoint paginates at 100 commits per page and this only
+    /// fetches the first page, so a PR with more than 100 commits is
+    /// treated as if it only had its first 100. Acceptable for now: a PR
+    /// that large is already far outside normal usage.
+    async fn fetch_pr_commits(&self, client: &Client, pr_number: u64) -> Result<Vec<Value>> {
         let url = format!(
-            "{}/repos/{}/pulls/{pr_number}",
+            "{}/repos/{}/pulls/{pr_number}/commits",
             self.config.api_base_url, self.config.repo
         );
-        let pr = self.get_json(client, &url, &[], "pull request").await?;
-        pr["commits"]
-            .as_u64()
-            .ok_or_else(|| anyhow!("pull request response did not include commits count"))
+        self.get_json_array(client, &url, &[("per_page", "100")], "pull request commits")
+            .await
+    }
+
+    /// Fetches the tree sha of a single commit.
+    async fn fetch_commit_tree_sha(&self, client: &Client, sha: &str) -> Result<String> {
+        let url = format!(
+            "{}/repos/{}/commits/{sha}",
+            self.config.api_base_url, self.config.repo
+        );
+        let commit = self.get_json(client, &url, &[], "commit").await?;
+        commit["commit"]["tree"]["sha"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("commit response did not include tree sha"))
     }
 
     /// Fetches `url` and decodes the response as JSON. `query` is appended
@@ -678,33 +731,35 @@ mod tests {
         }
     }
 
-    #[test]
-    fn merge_landed_as_one_commit_for_a_two_parent_merge() {
-        let commit = json!({
-            "parents": [{"sha": "base1"}, {"sha": "head1"}],
-            "commit": {"message": "Merge pull request #42 from user/branch"},
-        });
-        assert!(merge_landed_as_one_commit(&commit, 42));
+    fn pr_commit_with_tree(tree_sha: &str) -> Value {
+        json!({"commit": {"tree": {"sha": tree_sha}}})
     }
 
     #[test]
-    fn merge_landed_as_one_commit_for_githubs_default_squash_message() {
-        let commit = json!({
-            "parents": [{"sha": "base1"}],
-            "commit": {"message": "some change (#42)"},
-        });
-        assert!(merge_landed_as_one_commit(&commit, 42));
+    fn merge_looks_rebased_when_parent_tree_matches_second_to_last_commit() {
+        let pr_commits = vec![
+            pr_commit_with_tree("tree1"),
+            pr_commit_with_tree("tree2"),
+            pr_commit_with_tree("tree3"),
+        ];
+        assert!(merge_looks_rebased("tree2", &pr_commits));
     }
 
     #[test]
-    fn merge_did_not_land_as_one_commit_for_a_rebased_commit() {
-        // One parent, and the message doesn't reference this PR at all
-        // (it's the original commit message carried over by the rebase).
-        let commit = json!({
-            "parents": [{"sha": "rebased2"}],
-            "commit": {"message": "some change"},
-        });
-        assert!(!merge_landed_as_one_commit(&commit, 42));
+    fn merge_does_not_look_rebased_when_parent_tree_predates_the_pr() {
+        // A squash (or standard merge) commit's parent is the base tip
+        // from before the PR touched anything, with a tree unrelated to
+        // any of the PR's own commits.
+        let pr_commits = vec![pr_commit_with_tree("tree1"), pr_commit_with_tree("tree2")];
+        assert!(!merge_looks_rebased("unrelated-tree", &pr_commits));
+    }
+
+    #[test]
+    fn merge_does_not_look_rebased_for_a_single_commit_pr() {
+        // Squash and rebase are indistinguishable for a single-commit PR
+        // -- both land as exactly one commit -- so this is never "rebased".
+        let pr_commits = vec![pr_commit_with_tree("tree1")];
+        assert!(!merge_looks_rebased("tree1", &pr_commits));
     }
 
     #[test]

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -2,9 +2,50 @@ use std::fmt;
 
 use anyhow::{Result, anyhow, bail};
 use reqwest::{Client, RequestBuilder};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::{format::render_report, payload::ReportPayload, report::ZkVmResults};
+
+/// How many base-branch commits to walk back when looking for a baseline.
+const BASELINE_COMMIT_LOOKBACK: usize = 20;
+
+/// A performance report recovered from an already-merged PR, used as the
+/// baseline to diff a new report against.
+#[derive(Debug, Clone)]
+pub struct BaselineReport {
+    /// Number of the PR the baseline report was posted on.
+    pub pr_number: u64,
+    /// The base branch commit the baseline corresponds to.
+    pub commit_hash: String,
+    /// The machine-readable results recovered from the report comment.
+    pub payload: ReportPayload,
+}
+
+/// Returns the first comment whose body starts with the hidden marker.
+///
+/// Only a body that *starts* with the marker counts: the reporter always
+/// writes the marker first, so a comment that merely quotes it (e.g. a
+/// human discussing this report) is never mistaken for the sticky comment
+/// and overwritten.
+fn find_sticky_comment<'a>(comments: &'a [Value], hidden_marker: &str) -> Option<&'a Value> {
+    comments.iter().find(|comment| {
+        comment["body"]
+            .as_str()
+            .map(|body| body.starts_with(hidden_marker))
+            .unwrap_or(false)
+    })
+}
+
+/// Returns the number of the first of `pulls` that was merged into
+/// `base_branch`.
+fn first_merged_pr(pulls: &[Value], base_branch: &str) -> Option<u64> {
+    pulls
+        .iter()
+        .find(|pull| {
+            !pull["merged_at"].is_null() && pull["base"]["ref"].as_str() == Some(base_branch)
+        })
+        .and_then(|pull| pull["number"].as_u64())
+}
 
 /// Returns the report header identifying what was benchmarked.
 fn format_header(commit_hash: Option<&str>) -> String {
@@ -47,6 +88,9 @@ pub struct GithubPrReporterConfig {
     pub api_base_url: String,
     /// Commit hash shown in the report header, `None` for local runs.
     pub commit_hash: Option<String>,
+    /// Base branch searched for the baseline report, `None` to disable
+    /// baseline lookup.
+    pub base_branch: Option<String>,
 }
 
 impl Default for GithubPrReporterConfig {
@@ -59,6 +103,7 @@ impl Default for GithubPrReporterConfig {
             user_agent: DEFAULT_USER_AGENT.to_string(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             commit_hash: None,
+            base_branch: None,
         }
     }
 }
@@ -73,6 +118,7 @@ impl fmt::Debug for GithubPrReporterConfig {
             .field("user_agent", &self.user_agent)
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
+            .field("base_branch", &self.base_branch)
             .finish()
     }
 }
@@ -108,6 +154,57 @@ impl GithubPrReporter {
         Ok(Self { config })
     }
 
+    /// Fetches the baseline report to diff against: the payload embedded in
+    /// the sticky report comment of the most recently merged PR on the base
+    /// branch. Walks the base branch history commit by commit, so commits
+    /// without a merged PR (direct pushes) and PRs without a readable
+    /// report (failed perf job, predates the embedded payload) are skipped
+    /// in favor of an older baseline. Returns `None` when no base branch is
+    /// configured or nothing is found within the lookback window.
+    pub async fn fetch_baseline(&self) -> Result<Option<BaselineReport>> {
+        let Some(base_branch) = self.config.base_branch.as_deref() else {
+            return Ok(None);
+        };
+
+        let client = Client::new();
+        let commits_url = format!(
+            "{}/repos/{}/commits?sha={base_branch}&per_page={BASELINE_COMMIT_LOOKBACK}",
+            self.config.api_base_url, self.config.repo
+        );
+        let commits = self
+            .get_json_array(&client, &commits_url, "base branch commits")
+            .await?;
+
+        for commit in &commits {
+            let Some(sha) = commit["sha"].as_str() else {
+                continue;
+            };
+            let pulls_url = format!(
+                "{}/repos/{}/commits/{sha}/pulls",
+                self.config.api_base_url, self.config.repo
+            );
+            let pulls = self
+                .get_json_array(&client, &pulls_url, "associated pull requests")
+                .await?;
+            let Some(pr_number) = first_merged_pr(&pulls, base_branch) else {
+                continue;
+            };
+            let comments = self.fetch_comments(&client, pr_number).await?;
+            let Some(payload) = find_sticky_comment(&comments, &self.hidden_marker())
+                .and_then(|comment| comment["body"].as_str())
+                .and_then(ReportPayload::extract)
+            else {
+                continue;
+            };
+            return Ok(Some(BaselineReport {
+                pr_number,
+                commit_hash: sha.to_string(),
+                payload,
+            }));
+        }
+        Ok(None)
+    }
+
     /// Renders the results and posts them to the PR, updating the existing
     /// sticky comment if one is found. The posted comment also embeds the
     /// results as a hidden machine-readable payload, which is what later
@@ -122,51 +219,15 @@ impl GithubPrReporter {
     /// Posts the message to the PR, updating the existing sticky comment if
     /// one is found.
     async fn post(&self, message: &str) -> Result<()> {
-        let hidden_marker = format!("<!-- {} -->", self.config.marker);
+        let hidden_marker = self.hidden_marker();
         let body = format!("{hidden_marker}\n{message}");
 
         // TODO: set a request timeout on the client so a hung connection
         // fails on its own. Acceptable for now: this is expected to run in
         // CI, where the job-level timeout covers it.
         let client = Client::new();
-        // TODO: follow the `Link` header to paginate instead of fetching a
-        // single page; a sticky comment past the first 100 comments is
-        // missed and a duplicate gets created. Acceptable for now: the
-        // comment is posted right after the first CI run of a PR, so it
-        // lands within the first page.
-        let comments_url = format!(
-            "{}/repos/{}/issues/{}/comments?per_page=100",
-            self.config.api_base_url, self.config.repo, self.config.pr_number
-        );
-
-        let comments_response = self
-            .set_github_headers(client.get(&comments_url))
-            .send()
-            .await?;
-        if !comments_response.status().is_success() {
-            let status = comments_response.status();
-            let body = comments_response.text().await.unwrap_or_default();
-            bail!("failed to fetch PR comments ({status}): {body}");
-        }
-
-        // TODO: deserialize the comments into a typed struct instead of
-        // poking at `serde_json::Value`, for better errors when the
-        // response doesn't have the expected shape.
-        let comments: Vec<serde_json::Value> = comments_response
-            .json()
-            .await
-            .map_err(|e| anyhow!("failed to decode PR comments response: {e}"))?;
-
-        // Only a body that *starts* with the marker counts: the reporter
-        // always writes the marker first, so a comment that merely quotes
-        // it (e.g. a human discussing this report) is never mistaken for
-        // the sticky comment and overwritten.
-        let sticky_comment = comments.iter().find(|comment| {
-            comment["body"]
-                .as_str()
-                .map(|body| body.starts_with(&hidden_marker))
-                .unwrap_or(false)
-        });
+        let comments = self.fetch_comments(&client, self.config.pr_number).await?;
+        let sticky_comment = find_sticky_comment(&comments, &hidden_marker);
 
         let request = if let Some(existing_comment) = sticky_comment {
             let comment_url = existing_comment["url"]
@@ -174,7 +235,7 @@ impl GithubPrReporter {
                 .ok_or_else(|| anyhow!("existing sticky comment did not include url field"))?;
             client.patch(comment_url)
         } else {
-            client.post(&comments_url)
+            client.post(self.comments_url(self.config.pr_number))
         };
 
         let response = self
@@ -192,10 +253,80 @@ impl GithubPrReporter {
         Ok(())
     }
 
+    /// Returns the hidden HTML comment that identifies the sticky comment.
+    fn hidden_marker(&self) -> String {
+        format!("<!-- {} -->", self.config.marker)
+    }
+
+    fn comments_url(&self, pr_number: u64) -> String {
+        // TODO: follow the `Link` header to paginate instead of fetching a
+        // single page; a sticky comment past the first 100 comments is
+        // missed and a duplicate gets created. Acceptable for now: the
+        // comment is posted right after the first CI run of a PR, so it
+        // lands within the first page.
+        format!(
+            "{}/repos/{}/issues/{pr_number}/comments?per_page=100",
+            self.config.api_base_url, self.config.repo
+        )
+    }
+
+    async fn fetch_comments(&self, client: &Client, pr_number: u64) -> Result<Vec<Value>> {
+        self.get_json_array(client, &self.comments_url(pr_number), "PR comments")
+            .await
+    }
+
+    /// Fetches `url` and decodes the response as a JSON array.
+    async fn get_json_array(&self, client: &Client, url: &str, what: &str) -> Result<Vec<Value>> {
+        let response = self.set_github_headers(client.get(url)).send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("failed to fetch {what} ({status}): {body}");
+        }
+
+        // TODO: deserialize the responses into typed structs instead of
+        // poking at `serde_json::Value`, for better errors when a response
+        // doesn't have the expected shape.
+        response
+            .json()
+            .await
+            .map_err(|e| anyhow!("failed to decode {what} response: {e}"))
+    }
+
     fn set_github_headers(&self, builder: RequestBuilder) -> RequestBuilder {
         builder
             .header("Authorization", format!("Bearer {}", self.config.token))
             .header("X-GitHub-Api-Version", "2022-11-28")
             .header("User-Agent", &self.config.user_agent)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_sticky_comment_by_marker() {
+        let comments = vec![
+            json!({"body": "unrelated comment"}),
+            json!({"body": "quoting the `<!-- marker -->` trick", "url": "http://c/2"}),
+            json!({"body": "<!-- marker -->\nreport", "url": "http://c/3"}),
+            json!({"no_body": true}),
+        ];
+        let found = find_sticky_comment(&comments, "<!-- marker -->").unwrap();
+        assert_eq!(found["url"], "http://c/3");
+        assert!(find_sticky_comment(&comments, "<!-- other -->").is_none());
+    }
+
+    #[test]
+    fn picks_merged_pr_targeting_base_branch() {
+        let pulls = vec![
+            json!({"number": 1, "merged_at": null, "base": {"ref": "main"}}),
+            json!({"number": 2, "merged_at": "2026-07-01T00:00:00Z", "base": {"ref": "dev"}}),
+            json!({"number": 3, "merged_at": "2026-07-01T00:00:00Z", "base": {"ref": "main"}}),
+        ];
+        assert_eq!(first_merged_pr(&pulls, "main"), Some(3));
+        assert_eq!(first_merged_pr(&pulls, "dev"), Some(2));
+        assert_eq!(first_merged_pr(&pulls, "release"), None);
     }
 }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -28,6 +28,19 @@ pub struct BaselineReport {
     pub payload: ReportPayload,
 }
 
+/// A fixed point to anchor the baseline commit walk to: the PR's base
+/// branch name and the commit it pointed to when resolved.
+///
+/// Resolve this once, before doing any long-running work, and reuse it for
+/// [`GithubPrReporter::fetch_baseline`]. Re-resolving the base branch late
+/// (e.g. after benchmarks run) would let the walk start from whatever the
+/// branch has advanced to by then rather than what was actually tested.
+#[derive(Debug, Clone)]
+pub struct BaselineAnchor {
+    base_ref: String,
+    base_sha: String,
+}
+
 /// Returns the first comment whose body starts with the hidden marker.
 ///
 /// Only a body that *starts* with the marker counts: the reporter always
@@ -200,30 +213,54 @@ impl GithubPrReporter {
         Ok(Self { config })
     }
 
-    /// Fetches the baseline report to diff against: the payload embedded in
-    /// the sticky report comment of the most recently merged PR on the base
-    /// branch. The base branch is resolved from the PR being reported on,
-    /// so no configuration is needed and any trigger type works. Walks the
-    /// base branch history commit by commit, matching each commit to a
-    /// merged PR by `merge_commit_sha` rather than GitHub's commit-to-PR
-    /// association endpoint, which only reports merged PRs for commits
-    /// reachable from the repository's default branch and would otherwise
-    /// miss every PR merged into a non-default base. Commits without a
-    /// matching merged PR (direct pushes) and PRs without a readable report
-    /// (failed perf job, predates the embedded payload) are skipped in
-    /// favor of an older baseline. Returns `None` when the lookback is zero
-    /// or nothing is found within the lookback window; a missing baseline
-    /// only degrades the report to absolute numbers, so callers can treat
-    /// errors the same way.
-    pub async fn fetch_baseline(&self) -> Result<Option<BaselineReport>> {
-        // Guard explicitly: the GitHub API treats `per_page=0` as "use the
-        // default page size" rather than "no commits".
+    /// Resolves the anchor for the baseline commit walk: the PR's base
+    /// branch and the commit it currently points to. Call this before doing
+    /// any long-running work (e.g. before running benchmarks) and pass the
+    /// result to [`Self::fetch_baseline`] once that work is done.
+    ///
+    /// Resolving this late instead (i.e. inside `fetch_baseline`, after
+    /// benchmarks run) would let another PR merging into the base branch
+    /// while this job is queued or executing shift the walk to start from
+    /// that newer tip, selecting a baseline whose changes are absent from
+    /// what was actually tested. Returns `None` when the lookback is zero,
+    /// so callers don't pay for a PR fetch that would go unused.
+    pub async fn resolve_baseline_anchor(&self) -> Result<Option<BaselineAnchor>> {
         if self.config.baseline_commit_lookback == 0 {
             return Ok(None);
         }
 
         let client = Client::new();
-        let base_branch = self.fetch_pr_base_branch(&client).await?;
+        let url = format!(
+            "{}/repos/{}/pulls/{}",
+            self.config.api_base_url, self.config.repo, self.config.pr_number
+        );
+        let pr = self.get_json(&client, &url, &[], "pull request").await?;
+        let base_ref = pr["base"]["ref"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("pull request response did not include base.ref"))?;
+        let base_sha = pr["base"]["sha"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("pull request response did not include base.sha"))?;
+        Ok(Some(BaselineAnchor { base_ref, base_sha }))
+    }
+
+    /// Fetches the baseline report to diff against: the payload embedded in
+    /// the sticky report comment of the most recently merged PR on the base
+    /// branch. Walks the base branch history from `anchor` commit by
+    /// commit, matching each commit to a merged PR by `merge_commit_sha`
+    /// rather than GitHub's commit-to-PR association endpoint, which only
+    /// reports merged PRs for commits reachable from the repository's
+    /// default branch and would otherwise miss every PR merged into a
+    /// non-default base. Commits without a matching merged PR (direct
+    /// pushes) and PRs without a readable report (failed perf job, predates
+    /// the embedded payload) are skipped in favor of an older baseline.
+    /// Returns `None` when nothing is found within the lookback window; a
+    /// missing baseline only degrades the report to absolute numbers, so
+    /// callers can treat errors the same way.
+    pub async fn fetch_baseline(&self, anchor: &BaselineAnchor) -> Result<Option<BaselineReport>> {
+        let client = Client::new();
         // TODO: lookbacks above 100 are silently capped by the GitHub API,
         // which serves at most one page of commits; paginate to support
         // larger windows.
@@ -236,7 +273,7 @@ impl GithubPrReporter {
             .get_json_array(
                 &client,
                 &commits_url,
-                &[("sha", base_branch.as_str()), ("per_page", &lookback)],
+                &[("sha", anchor.base_sha.as_str()), ("per_page", &lookback)],
                 "base branch commits",
             )
             .await?;
@@ -259,7 +296,7 @@ impl GithubPrReporter {
                 &client,
                 &pulls_url,
                 &[
-                    ("base", base_branch.as_str()),
+                    ("base", anchor.base_ref.as_str()),
                     ("state", "closed"),
                     ("sort", "updated"),
                     ("direction", "desc"),
@@ -366,19 +403,6 @@ impl GithubPrReporter {
     /// Returns the hidden HTML comment that identifies the sticky comment.
     fn hidden_marker(&self) -> String {
         format!("<!-- {} -->", self.config.marker)
-    }
-
-    /// Returns the base branch of the PR the report is posted on.
-    async fn fetch_pr_base_branch(&self, client: &Client) -> Result<String> {
-        let url = format!(
-            "{}/repos/{}/pulls/{}",
-            self.config.api_base_url, self.config.repo, self.config.pr_number
-        );
-        let pr = self.get_json(client, &url, &[], "pull request").await?;
-        pr["base"]["ref"]
-            .as_str()
-            .map(str::to_string)
-            .ok_or_else(|| anyhow!("pull request response did not include base.ref"))
     }
 
     fn comments_url(&self, pr_number: u64) -> String {

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -77,6 +77,16 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
 /// Comparing trees rather than the commit message (which a maintainer can
 /// edit after the fact) makes this immune to that kind of drift.
 ///
+/// This heuristic can still be misled: if the PR's commits before the
+/// last happen to net to no tree change (e.g. an add followed by a
+/// revert), the pre-PR base tree can coincidentally equal the
+/// second-to-last commit's tree, misclassifying a squash as a rebase.
+/// Callers should only reach for this after a direct one-hop check
+/// against `payload.base_sha` has already failed -- that check is exact
+/// and always correct when it succeeds, so this is only ever asked to
+/// resolve genuinely ambiguous cases, never able to override a real
+/// match.
+///
 /// A single-commit PR is excluded: squash and rebase are indistinguishable
 /// for it (both land as exactly one commit), so there's nothing to tell
 /// apart.
@@ -426,10 +436,21 @@ impl GithubPrReporter {
             if payload.base_sha.is_none() {
                 continue;
             }
-            let commit_count = self
-                .resolve_landed_commit_count(&client, &tree_of, commit, pr_number)
-                .await?;
-            if !baseline_is_fresh(sha, commit_count, &parent_of, &payload) {
+            // Try the direct parent first: it's an exact sha comparison,
+            // so a match is always correct regardless of merge strategy,
+            // with no extra API calls. Only fall back to resolving the
+            // full landed span -- which relies on a tree-based heuristic
+            // that a coincidental no-net-change commit could mislead --
+            // when this doesn't already settle it.
+            let is_fresh = if baseline_is_fresh(sha, 1, &parent_of, &payload) {
+                true
+            } else {
+                let commit_count = self
+                    .resolve_landed_commit_count(&client, &tree_of, commit, pr_number)
+                    .await?;
+                baseline_is_fresh(sha, commit_count, &parent_of, &payload)
+            };
+            if !is_fresh {
                 continue;
             }
             return Ok(Some(BaselineReport {

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -225,8 +225,8 @@ impl GithubPrReporter {
         let client = Client::new();
         let base_branch = self.fetch_pr_base_branch(&client).await?;
         // TODO: lookbacks above 100 are silently capped by the GitHub API,
-        // which serves at most one page of commits or merged pull requests;
-        // paginate to support larger windows.
+        // which serves at most one page of commits; paginate to support
+        // larger windows.
         let lookback = self.config.baseline_commit_lookback.to_string();
         let commits_url = format!(
             "{}/repos/{}/commits",
@@ -245,6 +245,15 @@ impl GithubPrReporter {
             "{}/repos/{}/pulls",
             self.config.api_base_url, self.config.repo
         );
+        // `state=closed` includes closed-but-unmerged PRs alongside merged
+        // ones, so this page can't be capped to `lookback`: a burst of
+        // recently-updated rejected PRs would crowd out the merged PR that
+        // actually matches one of the fetched commits. Always ask for a
+        // full page (the GitHub API's max) instead.
+        //
+        // TODO: lookbacks above 100 are silently capped by the GitHub API,
+        // which serves at most one page of merged pull requests; paginate
+        // to support larger windows.
         let merged_pulls = self
             .get_json_array(
                 &client,
@@ -254,7 +263,7 @@ impl GithubPrReporter {
                     ("state", "closed"),
                     ("sort", "updated"),
                     ("direction", "desc"),
-                    ("per_page", &lookback),
+                    ("per_page", "100"),
                 ],
                 "merged pull requests",
             )

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -358,6 +358,11 @@ impl GithubPrReporter {
             bail!("expected comment author is required");
         }
         config.api_base_url = config.api_base_url.trim_end_matches('/').to_string();
+        // Surrounding whitespace would otherwise never equal a real GitHub
+        // login in find_sticky_comment's exact comparison, silently
+        // breaking both patching (every run creates a duplicate) and
+        // baseline lookups (every candidate is skipped).
+        config.expected_comment_author = config.expected_comment_author.trim().to_string();
         Ok(Self { config })
     }
 
@@ -854,6 +859,22 @@ mod tests {
             ..Default::default()
         };
         assert!(GithubPrReporter::new(config).is_err());
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace_from_expected_comment_author() {
+        let config = GithubPrReporterConfig {
+            repo: "owner/repo".to_string(),
+            token: "token".to_string(),
+            marker: "marker".to_string(),
+            expected_comment_author: " github-actions[bot] ".to_string(),
+            ..Default::default()
+        };
+        let reporter = GithubPrReporter::new(config).unwrap();
+        assert_eq!(
+            reporter.config.expected_comment_author,
+            "github-actions[bot]"
+        );
     }
 
     #[test]

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -261,20 +261,18 @@ impl GithubPrReporter {
     /// callers can treat errors the same way.
     pub async fn fetch_baseline(&self, anchor: &BaselineAnchor) -> Result<Option<BaselineReport>> {
         let client = Client::new();
-        // TODO: lookbacks above 100 are silently capped by the GitHub API,
-        // which serves at most one page of commits; paginate to support
-        // larger windows.
-        let lookback = self.config.baseline_commit_lookback.to_string();
+        let lookback = self.config.baseline_commit_lookback;
         let commits_url = format!(
             "{}/repos/{}/commits",
             self.config.api_base_url, self.config.repo
         );
         let commits = self
-            .get_json_array(
+            .get_json_array_paginated(
                 &client,
                 &commits_url,
-                &[("sha", anchor.base_sha.as_str()), ("per_page", &lookback)],
+                &[("sha", anchor.base_sha.as_str())],
                 "base branch commits",
+                lookback,
             )
             .await?;
 
@@ -283,16 +281,12 @@ impl GithubPrReporter {
             self.config.api_base_url, self.config.repo
         );
         // `state=closed` includes closed-but-unmerged PRs alongside merged
-        // ones, so this page can't be capped to `lookback`: a burst of
+        // ones, so this can't be capped to `lookback`: a burst of
         // recently-updated rejected PRs would crowd out the merged PR that
-        // actually matches one of the fetched commits. Always ask for a
-        // full page (the GitHub API's max) instead.
-        //
-        // TODO: lookbacks above 100 are silently capped by the GitHub API,
-        // which serves at most one page of merged pull requests; paginate
-        // to support larger windows.
+        // actually matches one of the fetched commits. Always search at
+        // least a full page.
         let merged_pulls = self
-            .get_json_array(
+            .get_json_array_paginated(
                 &client,
                 &pulls_url,
                 &[
@@ -300,9 +294,9 @@ impl GithubPrReporter {
                     ("state", "closed"),
                     ("sort", "updated"),
                     ("direction", "desc"),
-                    ("per_page", "100"),
                 ],
                 "merged pull requests",
+                lookback.max(100),
             )
             .await?;
 
@@ -466,6 +460,39 @@ impl GithubPrReporter {
             Value::Array(items) => Ok(items),
             _ => bail!("expected a JSON array in {what} response"),
         }
+    }
+
+    /// Fetches up to `limit` items from a paginated JSON array endpoint.
+    /// `query` should not include `per_page` or `page`: a full page (the
+    /// GitHub API's max of 100) is always requested, and further pages are
+    /// fetched until `limit` items have been collected or a short page
+    /// signals there are no more.
+    async fn get_json_array_paginated(
+        &self,
+        client: &Client,
+        url: &str,
+        query: &[(&str, &str)],
+        what: &str,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
+        const PAGE_SIZE: usize = 100;
+        let mut items = Vec::new();
+        let mut page = 1u32;
+        while items.len() < limit {
+            let page_str = page.to_string();
+            let mut paged_query = query.to_vec();
+            paged_query.push(("per_page", "100"));
+            paged_query.push(("page", &page_str));
+            let batch = self.get_json_array(client, url, &paged_query, what).await?;
+            let batch_len = batch.len();
+            items.extend(batch);
+            if batch_len < PAGE_SIZE {
+                break;
+            }
+            page += 1;
+        }
+        items.truncate(limit);
+        Ok(items)
     }
 
     fn set_github_headers(&self, builder: RequestBuilder) -> RequestBuilder {

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -64,24 +64,23 @@ fn short_hash(hash: &str) -> String {
 fn format_header(
     commit_hash: Option<&str>,
     baseline: Option<&BaselineReport>,
-    base_branch: Option<&str>,
+    lookup_enabled: bool,
 ) -> String {
     let mut lines = vec![match commit_hash {
         Some(hash) => format!("**Commit**: {}", short_hash(hash)),
         None => "**Local execution**".to_string(),
     }];
-    match (baseline, base_branch) {
-        (Some(baseline), _) => lines.push(format!(
+    match baseline {
+        Some(baseline) => lines.push(format!(
             "**Baseline**: #{} ({})",
             baseline.pr_number,
             short_hash(&baseline.commit_hash)
         )),
-        // A base branch was configured but yielded no baseline; say so to
-        // distinguish "nothing to compare against yet" from a broken lookup.
-        (None, Some(base_branch)) => {
-            lines.push(format!("**Baseline**: none found on `{base_branch}`"))
-        }
-        (None, None) => {}
+        // The lookup ran but yielded no baseline (e.g. no merged PR with a
+        // readable report yet); say so to distinguish "nothing to compare
+        // against" from lookup being disabled.
+        None if lookup_enabled => lines.push("**Baseline**: none found".to_string()),
+        None => {}
     }
     lines.join("\n")
 }
@@ -116,9 +115,6 @@ pub struct GithubPrReporterConfig {
     pub api_base_url: String,
     /// Commit hash shown in the report header, `None` for local runs.
     pub commit_hash: Option<String>,
-    /// Base branch searched for the baseline report, `None` to disable
-    /// baseline lookup.
-    pub base_branch: Option<String>,
     /// How many base-branch commits to walk back when looking for a
     /// baseline. Zero disables baseline lookup. See
     /// [`DEFAULT_BASELINE_COMMIT_LOOKBACK`] for how the window relates to
@@ -136,7 +132,6 @@ impl Default for GithubPrReporterConfig {
             user_agent: DEFAULT_USER_AGENT.to_string(),
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             commit_hash: None,
-            base_branch: None,
             baseline_commit_lookback: DEFAULT_BASELINE_COMMIT_LOOKBACK,
         }
     }
@@ -152,7 +147,6 @@ impl fmt::Debug for GithubPrReporterConfig {
             .field("user_agent", &self.user_agent)
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
-            .field("base_branch", &self.base_branch)
             .field("baseline_commit_lookback", &self.baseline_commit_lookback)
             .finish()
     }
@@ -191,16 +185,16 @@ impl GithubPrReporter {
 
     /// Fetches the baseline report to diff against: the payload embedded in
     /// the sticky report comment of the most recently merged PR on the base
-    /// branch. Walks the base branch history commit by commit, so commits
-    /// without a merged PR (direct pushes) and PRs without a readable
-    /// report (failed perf job, predates the embedded payload) are skipped
-    /// in favor of an older baseline. Returns `None` when baseline lookup
-    /// is disabled (no base branch, zero lookback) or nothing is found
-    /// within the lookback window.
+    /// branch. The base branch is resolved from the PR being reported on,
+    /// so no configuration is needed and any trigger type works. Walks the
+    /// base branch history commit by commit, so commits without a merged PR
+    /// (direct pushes) and PRs without a readable report (failed perf job,
+    /// predates the embedded payload) are skipped in favor of an older
+    /// baseline. Returns `None` when the lookback is zero or nothing is
+    /// found within the lookback window; a missing baseline only degrades
+    /// the report to absolute numbers, so callers can treat errors the same
+    /// way.
     pub async fn fetch_baseline(&self) -> Result<Option<BaselineReport>> {
-        let Some(base_branch) = self.config.base_branch.as_deref() else {
-            return Ok(None);
-        };
         // Guard explicitly: the GitHub API treats `per_page=0` as "use the
         // default page size" rather than "no commits".
         if self.config.baseline_commit_lookback == 0 {
@@ -208,6 +202,7 @@ impl GithubPrReporter {
         }
 
         let client = Client::new();
+        let base_branch = self.fetch_pr_base_branch(&client).await?;
         // TODO: lookbacks above 100 are silently capped by the GitHub API,
         // which serves at most one page of commits; paginate to support
         // larger windows.
@@ -230,7 +225,7 @@ impl GithubPrReporter {
             let pulls = self
                 .get_json_array(&client, &pulls_url, "associated pull requests")
                 .await?;
-            let Some(pr_number) = first_merged_pr(&pulls, base_branch) else {
+            let Some(pr_number) = first_merged_pr(&pulls, &base_branch) else {
                 continue;
             };
             let comments = self.fetch_comments(&client, pr_number).await?;
@@ -262,7 +257,7 @@ impl GithubPrReporter {
         let header = format_header(
             self.config.commit_hash.as_deref(),
             baseline,
-            self.config.base_branch.as_deref(),
+            self.config.baseline_commit_lookback > 0,
         );
         let payload = ReportPayload::from(results).embed()?;
         let report = render_report(results, baseline.map(|baseline| &baseline.payload));
@@ -312,6 +307,19 @@ impl GithubPrReporter {
         format!("<!-- {} -->", self.config.marker)
     }
 
+    /// Returns the base branch of the PR the report is posted on.
+    async fn fetch_pr_base_branch(&self, client: &Client) -> Result<String> {
+        let url = format!(
+            "{}/repos/{}/pulls/{}",
+            self.config.api_base_url, self.config.repo, self.config.pr_number
+        );
+        let pr = self.get_json(client, &url, "pull request").await?;
+        pr["base"]["ref"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("pull request response did not include base.ref"))
+    }
+
     fn comments_url(&self, pr_number: u64) -> String {
         // TODO: follow the `Link` header to paginate instead of fetching a
         // single page; a sticky comment past the first 100 comments is
@@ -329,8 +337,8 @@ impl GithubPrReporter {
             .await
     }
 
-    /// Fetches `url` and decodes the response as a JSON array.
-    async fn get_json_array(&self, client: &Client, url: &str, what: &str) -> Result<Vec<Value>> {
+    /// Fetches `url` and decodes the response as JSON.
+    async fn get_json(&self, client: &Client, url: &str, what: &str) -> Result<Value> {
         let response = self.set_github_headers(client.get(url)).send().await?;
         if !response.status().is_success() {
             let status = response.status();
@@ -345,6 +353,14 @@ impl GithubPrReporter {
             .json()
             .await
             .map_err(|e| anyhow!("failed to decode {what} response: {e}"))
+    }
+
+    /// Fetches `url` and decodes the response as a JSON array.
+    async fn get_json_array(&self, client: &Client, url: &str, what: &str) -> Result<Vec<Value>> {
+        match self.get_json(client, url, what).await? {
+            Value::Array(items) => Ok(items),
+            _ => bail!("expected a JSON array in {what} response"),
+        }
     }
 
     fn set_github_headers(&self, builder: RequestBuilder) -> RequestBuilder {

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -69,13 +69,28 @@ fn find_sticky_comment<'a>(
     })
 }
 
-/// Returns the number of the merged pull request in `merged_pulls` whose
-/// merge commit is `sha`.
-fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
+/// Returns the merged pull request in `merged_pulls` whose merge commit is
+/// `sha`.
+fn find_pr_for_merge_commit<'a>(merged_pulls: &'a [Value], sha: &str) -> Option<&'a Value> {
     merged_pulls
         .iter()
         .find(|pull| !pull["merged_at"].is_null() && pull["merge_commit_sha"].as_str() == Some(sha))
-        .and_then(|pull| pull["number"].as_u64())
+}
+
+/// Returns whether `payload_head_sha` (a candidate's tested head, from its
+/// embedded payload) matches `merged_head_sha` (that PR's own recorded
+/// `head.sha`).
+///
+/// A run whose CI succeeded and posted for one head, followed by a further
+/// push whose own CI run failed or was cancelled before it could post,
+/// leaves the sticky comment holding an earlier head's results even
+/// though a later head is what the PR actually merged. Both heads can
+/// share the same tested base, so the base-only freshness check can't
+/// catch this; comparing head identity closes that gap. A payload with no
+/// `head_sha` (e.g. posted before this field existed) can't be verified
+/// and is treated as not matching.
+fn tested_correct_head(payload_head_sha: Option<&str>, merged_head_sha: &str) -> bool {
+    payload_head_sha == Some(merged_head_sha)
 }
 
 /// Returns whether a merge commit whose first parent has author identity
@@ -473,7 +488,10 @@ impl GithubPrReporter {
             let Some(sha) = commit["sha"].as_str() else {
                 continue;
             };
-            let Some(pr_number) = find_pr_for_merge_commit(&merged_pulls, sha) else {
+            let Some(pull) = find_pr_for_merge_commit(&merged_pulls, sha) else {
+                continue;
+            };
+            let Some(pr_number) = pull["number"].as_u64() else {
                 continue;
             };
             let comments = self.fetch_comments(&client, pr_number).await?;
@@ -489,6 +507,18 @@ impl GithubPrReporter {
             // Skip the extra work below when there's nothing to validate
             // against anyway.
             if payload.base_sha.is_none() {
+                continue;
+            }
+            // Cheap and no extra API calls, so check head identity before
+            // the base freshness check below: both heads can share the
+            // same tested base, so this catches a candidate whose sticky
+            // comment was left holding an earlier head's results after a
+            // later head's own CI run failed or was cancelled before
+            // posting.
+            let Some(merged_head_sha) = pull["head"]["sha"].as_str() else {
+                continue;
+            };
+            if !tested_correct_head(payload.head_sha.as_deref(), merged_head_sha) {
                 continue;
             }
             // Try the direct parent first: it's an exact sha comparison,
@@ -549,8 +579,12 @@ impl GithubPrReporter {
             baseline,
             no_baseline_reason,
         );
-        let payload =
-            ReportPayload::new(results, anchor.map(|anchor| anchor.base_sha.clone())).embed()?;
+        let payload = ReportPayload::new(
+            results,
+            anchor.map(|anchor| anchor.base_sha.clone()),
+            self.config.head_sha.clone(),
+        )
+        .embed()?;
         let report = render_report(results, baseline.map(|baseline| &baseline.payload));
         let report_text = format!("{header}\n{report}\n{payload}");
         self.post(&report_text).await
@@ -853,14 +887,40 @@ mod tests {
             json!({"number": 2, "merged_at": "2026-07-01T00:00:00Z", "merge_commit_sha": "def456"}),
             json!({"number": 3, "merged_at": "2026-07-01T00:00:00Z", "merge_commit_sha": "abc123"}),
         ];
-        assert_eq!(find_pr_for_merge_commit(&merged_pulls, "abc123"), Some(3));
-        assert_eq!(find_pr_for_merge_commit(&merged_pulls, "def456"), Some(2));
-        assert_eq!(find_pr_for_merge_commit(&merged_pulls, "missing"), None);
+        assert_eq!(
+            find_pr_for_merge_commit(&merged_pulls, "abc123")
+                .and_then(|pull| pull["number"].as_u64()),
+            Some(3)
+        );
+        assert_eq!(
+            find_pr_for_merge_commit(&merged_pulls, "def456")
+                .and_then(|pull| pull["number"].as_u64()),
+            Some(2)
+        );
+        assert!(find_pr_for_merge_commit(&merged_pulls, "missing").is_none());
+    }
+
+    #[test]
+    fn tested_correct_head_matches_recorded_head() {
+        assert!(tested_correct_head(Some("head1"), "head1"));
+    }
+
+    #[test]
+    fn tested_correct_head_rejects_a_mismatched_head() {
+        // The sticky comment held an earlier head's results because a
+        // later head's own CI run failed or was cancelled before posting.
+        assert!(!tested_correct_head(Some("head1"), "head2"));
+    }
+
+    #[test]
+    fn tested_correct_head_rejects_a_missing_head() {
+        assert!(!tested_correct_head(None, "head1"));
     }
 
     fn payload_with_base_sha(base_sha: Option<&str>) -> ReportPayload {
         ReportPayload {
             base_sha: base_sha.map(str::to_string),
+            head_sha: None,
             zkvms: Vec::new(),
         }
     }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -57,12 +57,24 @@ fn short_hash(hash: &str) -> String {
     hash.chars().take(8).collect()
 }
 
+/// Why no baseline is available, used by [`format_header`] to describe a
+/// missing baseline accurately instead of always reading as a clean miss.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum NoBaselineReason {
+    /// Baseline lookup is disabled (`baseline_commit_lookback == 0`).
+    LookupDisabled,
+    /// The lookup ran to completion and found nothing within the window.
+    NotFound,
+    /// The lookup itself failed, e.g. a network or API error.
+    LookupFailed,
+}
+
 /// Returns the report header identifying what was benchmarked and which
 /// baseline it is compared against.
 fn format_header(
     commit_hash: Option<&str>,
     baseline: Option<&BaselineReport>,
-    lookup_enabled: bool,
+    no_baseline_reason: NoBaselineReason,
 ) -> String {
     let mut lines = vec![match commit_hash {
         Some(hash) => format!("**Commit**: {}", short_hash(hash)),
@@ -77,7 +89,14 @@ fn format_header(
         // The lookup ran but yielded no baseline (e.g. no merged PR with a
         // readable report yet); say so to distinguish "nothing to compare
         // against" from lookup being disabled.
-        None if lookup_enabled => lines.push("**Baseline**: none found".to_string()),
+        None if no_baseline_reason == NoBaselineReason::NotFound => {
+            lines.push("**Baseline**: none found".to_string())
+        }
+        // The lookup didn't run to completion, so "none found" would
+        // misrepresent a transient failure as a confirmed clean miss.
+        None if no_baseline_reason == NoBaselineReason::LookupFailed => {
+            lines.push("**Baseline**: lookup failed, see job logs".to_string())
+        }
         None => {}
     }
     lines.join("\n")
@@ -269,15 +288,28 @@ impl GithubPrReporter {
     /// `baseline` is given. The posted comment also embeds the results as a
     /// hidden machine-readable payload, which is what later runs read back
     /// as their baseline.
+    ///
+    /// `baseline_lookup_failed` should be set when the caller's
+    /// [`Self::fetch_baseline`] call returned `Err` rather than `Ok(None)`,
+    /// so the posted header can say the lookup failed instead of implying a
+    /// confirmed clean miss.
     pub async fn post_report(
         &self,
         results: &[ZkVmResults],
         baseline: Option<&BaselineReport>,
+        baseline_lookup_failed: bool,
     ) -> Result<()> {
+        let no_baseline_reason = if baseline_lookup_failed {
+            NoBaselineReason::LookupFailed
+        } else if self.config.baseline_commit_lookback > 0 {
+            NoBaselineReason::NotFound
+        } else {
+            NoBaselineReason::LookupDisabled
+        };
         let header = format_header(
             self.config.commit_hash.as_deref(),
             baseline,
-            self.config.baseline_commit_lookback > 0,
+            no_baseline_reason,
         );
         let payload = ReportPayload::from(results).embed()?;
         let report = render_report(results, baseline.map(|baseline| &baseline.payload));

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -71,23 +71,26 @@ fn find_pr_for_merge_commit(merged_pulls: &[Value], sha: &str) -> Option<u64> {
 /// Returns whether `payload` was tested against exactly the base state the
 /// candidate's commit span landed on.
 ///
-/// Starting at `merge_sha` (the candidate's merge commit), walks back
-/// through first-parent links looking for `payload.base_sha`: one hop for
-/// a squash commit or a standard two-parent merge commit, one hop per
-/// rebased commit for rebase-and-merge, since GitHub replays each of the
-/// PR's commits individually onto the base tip and every one of them
-/// lands in the base branch's own history. `parent_of` should map each
-/// base-branch commit's sha to its first parent's sha, built from the
-/// already-fetched commit history.
+/// Walks back exactly `commit_count` first-parent hops from `merge_sha`
+/// (the candidate's merge commit) -- one hop per commit this PR actually
+/// contributed, whether that's a single squash/merge commit or every
+/// commit replayed by rebase-and-merge -- and checks whether the resulting
+/// commit is `payload.base_sha`. `parent_of` should map each base-branch
+/// commit's sha to its first parent's sha, built from the already-fetched
+/// commit history.
 ///
-/// If the base branch advanced after the candidate PR's last CI run but
-/// before it merged, `payload.base_sha` won't appear anywhere in this
-/// walk; using such a payload as a baseline would silently attribute the
-/// base branch's intervening changes to whichever PR is compared against
-/// it next. A payload with no `base_sha` (e.g. posted before this field
-/// existed) can't be verified and is treated as stale.
+/// The walk must stop at exactly `commit_count` hops rather than
+/// continuing until *some* match turns up: the base branch's history is
+/// linear and only grows, so searching further back would also find (and
+/// wrongly accept) an older `base_sha` that the candidate was tested
+/// against before some unrelated PR advanced the base in between -- the
+/// exact staleness this check exists to catch.
+///
+/// A payload with no `base_sha` (e.g. posted before this field existed)
+/// can't be verified and is treated as stale.
 fn baseline_is_fresh(
     merge_sha: &str,
+    commit_count: u64,
     parent_of: &HashMap<&str, &str>,
     payload: &ReportPayload,
 ) -> bool {
@@ -95,13 +98,13 @@ fn baseline_is_fresh(
         return false;
     };
     let mut sha = merge_sha;
-    while let Some(&parent_sha) = parent_of.get(sha) {
-        if parent_sha == tested_base_sha {
-            return true;
-        }
+    for _ in 0..commit_count {
+        let Some(&parent_sha) = parent_of.get(sha) else {
+            return false;
+        };
         sha = parent_sha;
     }
-    false
+    sha == tested_base_sha
 }
 
 /// Returns the first 8 characters of a commit hash.
@@ -413,7 +416,13 @@ impl GithubPrReporter {
             else {
                 continue;
             };
-            if !baseline_is_fresh(sha, &parent_of, &payload) {
+            // Skip the extra API call below when there's nothing to
+            // validate against anyway.
+            if payload.base_sha.is_none() {
+                continue;
+            }
+            let commit_count = self.fetch_pr_commit_count(&client, pr_number).await?;
+            if !baseline_is_fresh(sha, commit_count, &parent_of, &payload) {
                 continue;
             }
             return Ok(Some(BaselineReport {
@@ -521,6 +530,21 @@ impl GithubPrReporter {
     async fn fetch_comments(&self, client: &Client, pr_number: u64) -> Result<Vec<Value>> {
         self.get_json_array(client, &self.comments_url(pr_number), &[], "PR comments")
             .await
+    }
+
+    /// Returns the number of commits in PR `pr_number`, used to bound
+    /// [`baseline_is_fresh`]'s parent walk to exactly that PR's own commit
+    /// span. The list-pulls endpoint used to build `merged_pulls` doesn't
+    /// include this count; only the single-PR endpoint does.
+    async fn fetch_pr_commit_count(&self, client: &Client, pr_number: u64) -> Result<u64> {
+        let url = format!(
+            "{}/repos/{}/pulls/{pr_number}",
+            self.config.api_base_url, self.config.repo
+        );
+        let pr = self.get_json(client, &url, &[], "pull request").await?;
+        pr["commits"]
+            .as_u64()
+            .ok_or_else(|| anyhow!("pull request response did not include commits count"))
     }
 
     /// Fetches `url` and decodes the response as JSON. `query` is appended
@@ -650,7 +674,7 @@ mod tests {
     fn baseline_is_fresh_when_tested_base_matches_merge_parent() {
         let parent_of = HashMap::from([("merge1", "base1")]);
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(baseline_is_fresh("merge1", &parent_of, &payload));
+        assert!(baseline_is_fresh("merge1", 1, &parent_of, &payload));
     }
 
     #[test]
@@ -664,7 +688,7 @@ mod tests {
             ("rebased1", "base1"),
         ]);
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(baseline_is_fresh("rebased3", &parent_of, &payload));
+        assert!(baseline_is_fresh("rebased3", 3, &parent_of, &payload));
     }
 
     #[test]
@@ -673,20 +697,33 @@ mod tests {
         // merged the base branch had moved on to `base2`.
         let parent_of = HashMap::from([("merge1", "base2")]);
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(!baseline_is_fresh("merge1", &parent_of, &payload));
+        assert!(!baseline_is_fresh("merge1", 1, &parent_of, &payload));
+    }
+
+    #[test]
+    fn baseline_is_stale_when_an_older_base_sha_is_reachable_further_back() {
+        // The candidate (a single-commit PR) was tested against `base1`,
+        // but an unrelated PR advanced the base to `base2` before the
+        // candidate merged, so its merge parent is `base2`, not `base1`.
+        // `base1` is still reachable further up the chain -- as ordinary
+        // history, not as part of this candidate's own span -- and must
+        // not be mistaken for a match.
+        let parent_of = HashMap::from([("merge1", "base2"), ("base2", "base1")]);
+        let payload = payload_with_base_sha(Some("base1"));
+        assert!(!baseline_is_fresh("merge1", 1, &parent_of, &payload));
     }
 
     #[test]
     fn baseline_is_stale_without_a_tested_base_sha() {
         let parent_of = HashMap::from([("merge1", "base1")]);
         let payload = payload_with_base_sha(None);
-        assert!(!baseline_is_fresh("merge1", &parent_of, &payload));
+        assert!(!baseline_is_fresh("merge1", 1, &parent_of, &payload));
     }
 
     #[test]
     fn baseline_is_stale_without_commit_parents() {
         let parent_of = HashMap::new();
         let payload = payload_with_base_sha(Some("base1"));
-        assert!(!baseline_is_fresh("merge1", &parent_of, &payload));
+        assert!(!baseline_is_fresh("merge1", 1, &parent_of, &payload));
     }
 }

--- a/perf-report/src/github.rs
+++ b/perf-report/src/github.rs
@@ -6,8 +6,15 @@ use serde_json::{Value, json};
 
 use crate::{format::render_report, payload::ReportPayload, report::ZkVmResults};
 
-/// How many base-branch commits to walk back when looking for a baseline.
-const BASELINE_COMMIT_LOOKBACK: usize = 20;
+/// Default number of base-branch commits to walk back when looking for a
+/// baseline.
+///
+/// The window counts commits, not PRs. Under squash merging every base
+/// branch commit corresponds to one PR, so this spans ~20 PRs. Under
+/// rebase or merge-commit merging a single PR lands all of its commits on
+/// the base branch, so one large PR can consume most of the window;
+/// configure a larger lookback in such repositories.
+pub const DEFAULT_BASELINE_COMMIT_LOOKBACK: usize = 20;
 
 /// A performance report recovered from an already-merged PR, used as the
 /// baseline to diff a new report against.
@@ -112,6 +119,11 @@ pub struct GithubPrReporterConfig {
     /// Base branch searched for the baseline report, `None` to disable
     /// baseline lookup.
     pub base_branch: Option<String>,
+    /// How many base-branch commits to walk back when looking for a
+    /// baseline. Zero disables baseline lookup. See
+    /// [`DEFAULT_BASELINE_COMMIT_LOOKBACK`] for how the window relates to
+    /// the repository's merge strategy.
+    pub baseline_commit_lookback: usize,
 }
 
 impl Default for GithubPrReporterConfig {
@@ -125,6 +137,7 @@ impl Default for GithubPrReporterConfig {
             api_base_url: DEFAULT_API_BASE_URL.to_string(),
             commit_hash: None,
             base_branch: None,
+            baseline_commit_lookback: DEFAULT_BASELINE_COMMIT_LOOKBACK,
         }
     }
 }
@@ -140,6 +153,7 @@ impl fmt::Debug for GithubPrReporterConfig {
             .field("api_base_url", &self.api_base_url)
             .field("commit_hash", &self.commit_hash)
             .field("base_branch", &self.base_branch)
+            .field("baseline_commit_lookback", &self.baseline_commit_lookback)
             .finish()
     }
 }
@@ -180,17 +194,26 @@ impl GithubPrReporter {
     /// branch. Walks the base branch history commit by commit, so commits
     /// without a merged PR (direct pushes) and PRs without a readable
     /// report (failed perf job, predates the embedded payload) are skipped
-    /// in favor of an older baseline. Returns `None` when no base branch is
-    /// configured or nothing is found within the lookback window.
+    /// in favor of an older baseline. Returns `None` when baseline lookup
+    /// is disabled (no base branch, zero lookback) or nothing is found
+    /// within the lookback window.
     pub async fn fetch_baseline(&self) -> Result<Option<BaselineReport>> {
         let Some(base_branch) = self.config.base_branch.as_deref() else {
             return Ok(None);
         };
+        // Guard explicitly: the GitHub API treats `per_page=0` as "use the
+        // default page size" rather than "no commits".
+        if self.config.baseline_commit_lookback == 0 {
+            return Ok(None);
+        }
 
         let client = Client::new();
+        // TODO: lookbacks above 100 are silently capped by the GitHub API,
+        // which serves at most one page of commits; paginate to support
+        // larger windows.
         let commits_url = format!(
-            "{}/repos/{}/commits?sha={base_branch}&per_page={BASELINE_COMMIT_LOOKBACK}",
-            self.config.api_base_url, self.config.repo
+            "{}/repos/{}/commits?sha={base_branch}&per_page={}",
+            self.config.api_base_url, self.config.repo, self.config.baseline_commit_lookback
         );
         let commits = self
             .get_json_array(&client, &commits_url, "base branch commits")

--- a/perf-report/src/lib.rs
+++ b/perf-report/src/lib.rs
@@ -14,7 +14,8 @@ mod report;
 pub use args::GithubReportArgs;
 pub use format::{format_results, render_report};
 pub use github::{
-    DEFAULT_API_BASE_URL, DEFAULT_USER_AGENT, GithubPrReporter, GithubPrReporterConfig,
+    BaselineReport, DEFAULT_API_BASE_URL, DEFAULT_USER_AGENT, GithubPrReporter,
+    GithubPrReporterConfig,
 };
 pub use payload::{ProgramPayload, ReportPayload, ZkVmPayload};
 pub use report::{ProgramResult, ZkVmResults};

--- a/perf-report/src/lib.rs
+++ b/perf-report/src/lib.rs
@@ -1,11 +1,14 @@
 //! Formatting and publishing of zkVM performance reports.
 //!
 //! Two parts: a formatter that renders per-zkVM
-//! [`ExecutionSummary`](zkaleido::ExecutionSummary) results as a report, and
-//! a GitHub poster that publishes it as a "sticky" comment on a PR: the
-//! first post creates the comment, subsequent posts update it in place.
+//! [`ExecutionSummary`](zkaleido::ExecutionSummary) results as a report,
+//! optionally with per-program deltas against a baseline recovered from the
+//! last merged PR, and a GitHub poster that publishes it as a "sticky"
+//! comment on a PR: the first post creates the comment, subsequent posts
+//! update it in place.
 
 mod args;
+mod diff;
 mod format;
 mod github;
 mod payload;

--- a/perf-report/src/lib.rs
+++ b/perf-report/src/lib.rs
@@ -18,7 +18,7 @@ pub use args::GithubReportArgs;
 pub use format::{format_results, render_report};
 pub use github::{
     BaselineAnchor, BaselineReport, DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK,
-    DEFAULT_USER_AGENT, GithubPrReporter, GithubPrReporterConfig,
+    DEFAULT_EXPECTED_COMMENT_AUTHOR, DEFAULT_USER_AGENT, GithubPrReporter, GithubPrReporterConfig,
 };
 pub use payload::{ProgramPayload, ReportPayload, ZkVmPayload};
 pub use report::{ProgramResult, ZkVmResults};

--- a/perf-report/src/lib.rs
+++ b/perf-report/src/lib.rs
@@ -17,8 +17,8 @@ mod report;
 pub use args::GithubReportArgs;
 pub use format::{format_results, render_report};
 pub use github::{
-    BaselineReport, DEFAULT_API_BASE_URL, DEFAULT_USER_AGENT, GithubPrReporter,
-    GithubPrReporterConfig,
+    BaselineReport, DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK, DEFAULT_USER_AGENT,
+    GithubPrReporter, GithubPrReporterConfig,
 };
 pub use payload::{ProgramPayload, ReportPayload, ZkVmPayload};
 pub use report::{ProgramResult, ZkVmResults};

--- a/perf-report/src/lib.rs
+++ b/perf-report/src/lib.rs
@@ -17,8 +17,8 @@ mod report;
 pub use args::GithubReportArgs;
 pub use format::{format_results, render_report};
 pub use github::{
-    BaselineReport, DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK, DEFAULT_USER_AGENT,
-    GithubPrReporter, GithubPrReporterConfig,
+    BaselineAnchor, BaselineReport, DEFAULT_API_BASE_URL, DEFAULT_BASELINE_COMMIT_LOOKBACK,
+    DEFAULT_USER_AGENT, GithubPrReporter, GithubPrReporterConfig,
 };
 pub use payload::{ProgramPayload, ReportPayload, ZkVmPayload};
 pub use report::{ProgramResult, ZkVmResults};

--- a/perf-report/src/payload.rs
+++ b/perf-report/src/payload.rs
@@ -28,6 +28,17 @@ pub struct ReportPayload {
     /// still decodes, as `None`.
     #[serde(default)]
     pub base_sha: Option<String>,
+    /// The PR head commit this report was actually tested against, `None`
+    /// if unavailable (e.g. outside CI). A later baseline walk uses this
+    /// to detect a candidate whose CI run posted successfully for an
+    /// earlier head, then failed or was cancelled for a later head before
+    /// it could post -- leaving the sticky comment describing a commit
+    /// that isn't what the PR actually merged. The base-only freshness
+    /// check can't catch this, since both heads can share the same tested
+    /// base. `#[serde(default)]` so a payload posted before this field
+    /// existed still decodes, as `None`.
+    #[serde(default)]
+    pub head_sha: Option<String>,
     /// Per-zkVM results.
     pub zkvms: Vec<ZkVmPayload>,
 }
@@ -84,14 +95,20 @@ impl ZkVmPayload {
 impl ReportPayload {
     /// Builds the payload embedded in a posted report. `base_sha` should be
     /// the base commit resolved by the run's [`BaselineAnchor`], `None` if
-    /// no anchor was resolved (lookup disabled or failed), which makes this
-    /// payload unusable as a future baseline since there is nothing to
-    /// validate it against.
+    /// no anchor was resolved (lookup disabled or failed); `head_sha`
+    /// should be the PR head commit this run tested, `None` outside CI.
+    /// Either being `None` makes this payload unusable as a future
+    /// baseline since there is nothing to validate it against.
     ///
     /// [`BaselineAnchor`]: crate::BaselineAnchor
-    pub fn new(results: &[ZkVmResults], base_sha: Option<String>) -> Self {
+    pub fn new(
+        results: &[ZkVmResults],
+        base_sha: Option<String>,
+        head_sha: Option<String>,
+    ) -> Self {
         Self {
             base_sha,
+            head_sha,
             zkvms: results
                 .iter()
                 .map(|zkvm_results| ZkVmPayload {
@@ -118,6 +135,7 @@ mod tests {
     fn sample_payload() -> ReportPayload {
         ReportPayload {
             base_sha: Some("abc123".to_string()),
+            head_sha: Some("head123".to_string()),
             zkvms: vec![ZkVmPayload {
                 zkvm: "SP1".to_string(),
                 results: vec![

--- a/perf-report/src/payload.rs
+++ b/perf-report/src/payload.rs
@@ -17,6 +17,17 @@ const DATA_MARKER_SUFFIX: &str = "-->";
 /// fails to decode is treated as "no baseline".
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReportPayload {
+    /// The base branch commit this report was actually tested against
+    /// (from the resolved baseline anchor), `None` if the anchor couldn't
+    /// be resolved. A later baseline walk uses this to detect a candidate
+    /// whose base branch advanced after it was last benchmarked but before
+    /// it merged: the payload would then describe a tree that never
+    /// existed in the branch's history, silently attributing the base's
+    /// intervening changes to whichever PR is compared against it next.
+    /// `#[serde(default)]` so a payload posted before this field existed
+    /// still decodes, as `None`.
+    #[serde(default)]
+    pub base_sha: Option<String>,
     /// Per-zkVM results.
     pub zkvms: Vec<ZkVmPayload>,
 }
@@ -70,9 +81,17 @@ impl ZkVmPayload {
     }
 }
 
-impl From<&[ZkVmResults]> for ReportPayload {
-    fn from(results: &[ZkVmResults]) -> Self {
+impl ReportPayload {
+    /// Builds the payload embedded in a posted report. `base_sha` should be
+    /// the base commit resolved by the run's [`BaselineAnchor`], `None` if
+    /// no anchor was resolved (lookup disabled or failed), which makes this
+    /// payload unusable as a future baseline since there is nothing to
+    /// validate it against.
+    ///
+    /// [`BaselineAnchor`]: crate::BaselineAnchor
+    pub fn new(results: &[ZkVmResults], base_sha: Option<String>) -> Self {
         Self {
+            base_sha,
             zkvms: results
                 .iter()
                 .map(|zkvm_results| ZkVmPayload {
@@ -98,6 +117,7 @@ mod tests {
 
     fn sample_payload() -> ReportPayload {
         ReportPayload {
+            base_sha: Some("abc123".to_string()),
             zkvms: vec![ZkVmPayload {
                 zkvm: "SP1".to_string(),
                 results: vec![

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -21,6 +21,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|github| github.reporter(COMMENT_MARKER))
         .transpose()?;
 
+    // Resolve the baseline anchor before running benchmarks: doing it after
+    // would let a PR merging into the base branch during this (potentially
+    // long) run shift the walk to a commit whose changes are absent from
+    // what was actually tested.
+    let mut baseline_lookup_failed = false;
+    let baseline_anchor = match &reporter {
+        Some(reporter) => match reporter.resolve_baseline_anchor().await {
+            Ok(anchor) => anchor,
+            Err(err) => {
+                eprintln!("warning: failed to resolve baseline anchor: {err:#}");
+                baseline_lookup_failed = true;
+                None
+            }
+        },
+        None => None,
+    };
+
     let mut results: Vec<ZkVmResults> = Vec::new();
 
     #[cfg(feature = "sp1")]
@@ -38,9 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // A missing baseline only degrades the report to absolute numbers, so
     // fetch failures must not block posting it, but the reported header
     // should still say the lookup failed rather than implying a clean miss.
-    let mut baseline_lookup_failed = false;
-    let baseline = match &reporter {
-        Some(reporter) => match reporter.fetch_baseline().await {
+    let baseline = match (&reporter, baseline_anchor) {
+        (Some(reporter), Some(anchor)) => match reporter.fetch_baseline(&anchor).await {
             Ok(baseline) => baseline,
             Err(err) => {
                 eprintln!("warning: failed to fetch baseline report: {err:#}");
@@ -48,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 None
             }
         },
-        None => None,
+        _ => None,
     };
 
     // Print results

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -36,11 +36,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Print results
-    println!("{}", render_report(&results));
+    println!("{}", render_report(&results, None));
 
     // Post to GitHub PR
     if let Some(reporter) = reporter {
-        reporter.post_report(&results).await?;
+        reporter.post_report(&results, None).await?;
     }
 
     Ok(())

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -35,12 +35,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         results.push(ZkVmResults::new(ZkVm::Risc0, risc0_reports));
     }
 
+    // A missing baseline only degrades the report to absolute numbers, so
+    // fetch failures must not block posting it.
+    let baseline = match &reporter {
+        Some(reporter) => reporter.fetch_baseline().await.unwrap_or_else(|err| {
+            eprintln!("warning: failed to fetch baseline report: {err:#}");
+            None
+        }),
+        None => None,
+    };
+
     // Print results
-    println!("{}", render_report(&results, None));
+    println!(
+        "{}",
+        render_report(
+            &results,
+            baseline.as_ref().map(|baseline| &baseline.payload)
+        )
+    );
 
     // Post to GitHub PR
     if let Some(reporter) = reporter {
-        reporter.post_report(&results, None).await?;
+        reporter.post_report(&results, baseline.as_ref()).await?;
     }
 
     Ok(())

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -36,12 +36,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // A missing baseline only degrades the report to absolute numbers, so
-    // fetch failures must not block posting it.
+    // fetch failures must not block posting it, but the reported header
+    // should still say the lookup failed rather than implying a clean miss.
+    let mut baseline_lookup_failed = false;
     let baseline = match &reporter {
-        Some(reporter) => reporter.fetch_baseline().await.unwrap_or_else(|err| {
-            eprintln!("warning: failed to fetch baseline report: {err:#}");
-            None
-        }),
+        Some(reporter) => match reporter.fetch_baseline().await {
+            Ok(baseline) => baseline,
+            Err(err) => {
+                eprintln!("warning: failed to fetch baseline report: {err:#}");
+                baseline_lookup_failed = true;
+                None
+            }
+        },
         None => None,
     };
 
@@ -56,7 +62,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Post to GitHub PR
     if let Some(reporter) = reporter {
-        reporter.post_report(&results, baseline.as_ref()).await?;
+        reporter
+            .post_report(&results, baseline.as_ref(), baseline_lookup_failed)
+            .await?;
     }
 
     Ok(())

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -55,8 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // A missing baseline only degrades the report to absolute numbers, so
     // fetch failures must not block posting it, but the reported header
     // should still say the lookup failed rather than implying a clean miss.
-    let baseline = match (&reporter, baseline_anchor) {
-        (Some(reporter), Some(anchor)) => match reporter.fetch_baseline(&anchor).await {
+    let baseline = match (&reporter, &baseline_anchor) {
+        (Some(reporter), Some(anchor)) => match reporter.fetch_baseline(anchor).await {
             Ok(baseline) => baseline,
             Err(err) => {
                 eprintln!("warning: failed to fetch baseline report: {err:#}");
@@ -79,7 +79,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Post to GitHub PR
     if let Some(reporter) = reporter {
         reporter
-            .post_report(&results, baseline.as_ref(), baseline_lookup_failed)
+            .post_report(
+                &results,
+                baseline.as_ref(),
+                baseline_lookup_failed,
+                baseline_anchor.as_ref(),
+            )
             .await?;
     }
 


### PR DESCRIPTION
## Description

Makes the perf report show per-program deltas against the last merged PR, so a PR's comment answers "did this change make things faster or slower" instead of just printing absolute numbers.

With a baseline, tables gain `Δ cycles` / `Δ gas` columns (`+1,234 (+5.6%)`, `new` for programs the baseline doesn't cover) and the header names the baseline PR and commit. Baseline lookup failures never block the report; it falls back to absolute numbers with a warning.
### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests

## Notes to Reviewers

The baseline is discovered by walking the base branch's commit history and taking the first commit whose merged PR carries a readable report: this anchors the comparison to the code the PR actually diffs against (rather than the most recently merged PR repo-wide), and it degrades to an older baseline when the newest merged PR has no usable report (failed perf job, or it predates the embedded payload). The numbers themselves are recovered from the hidden machine-readable payload that #165 now embeds in every posted comment — the human-facing table is never parsed, so its format stays free to change (this PR changes it).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-2719
