### PR TITLE
fix(ci): use self-repository action syntax

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# actionlint 1.7.12 predates GitHub's $/ self-repository syntax.
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'specifying action "\$/\.github/actions/.+" in invalid format because ref is missing'
+      - 'reusable workflow call "\$/\.github/workflows/.+" at "uses" is not following the format'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   clippy:
     name: Run clippy on crates
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchains
-        uses: ./.github/actions/toolchains # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/toolchains # zizmor: ignore[unpinned-uses]
       - name: Install Rust toolchain
         run: rustup show
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -78,9 +78,9 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
       - name: Install toolchains
-        uses: ./.github/actions/toolchains # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/toolchains # zizmor: ignore[unpinned-uses]
 
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUST_VERSION"

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   eval_perf:
     permissions:
@@ -39,9 +39,9 @@ jobs:
           RUST_VERSION: ${{ needs.extract-rust-version.outputs.rust-version }}
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
       - name: Install toolchains
-        uses: ./.github/actions/toolchains # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/toolchains # zizmor: ignore[unpinned-uses]
 
       - name: Use Cargo cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
       - name: Extract Rust toolchain version
         id: extract
-        uses: ./.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/extract-rust-version # zizmor: ignore[unpinned-uses]
 
   test:
     name: Run unit tests and generate report
@@ -43,9 +43,9 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
       - name: Install toolchains
-        uses: ./.github/actions/toolchains # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/toolchains # zizmor: ignore[unpinned-uses]
 
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUST_VERSION" --component llvm-tools-preview
@@ -91,9 +91,9 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
       - name: Install toolchains
-        uses: ./.github/actions/toolchains # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/toolchains # zizmor: ignore[unpinned-uses]
 
       - name: Install Rust toolchain
         run: rustup toolchain install "$RUST_VERSION"


### PR DESCRIPTION
## Description

Use GitHub's `$/` syntax for actions stored in this repository. zizmor 1.30.0 now requires this form and was failing every pull request with 12 `self-repository` findings.

The actionlint config ignores the two errors produced by actionlint 1.7.12, which does not recognize the new syntax yet.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Validated with the same zizmor 1.30.0 release that failed in GitHub Actions. All workflow and action YAML files also parse successfully.

No new tests were added because this only changes GitHub Actions references.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A